### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/extras/qpsclient.py
+++ b/extras/qpsclient.py
@@ -41,7 +41,7 @@ class QPSSpider(Spider):
 
         slots = int(self.slots)
         if slots > 1:
-            urls = [url.replace('localhost', '127.0.0.%d' % (x + 1)) for x in xrange(slots)]
+            urls = [url.replace('localhost', '127.0.0.{0:d}'.format((x + 1))) for x in xrange(slots)]
         else:
             urls = [url]
 

--- a/scrapy/__init__.py
+++ b/scrapy/__init__.py
@@ -15,7 +15,7 @@ del pkgutil
 # Check minimum required Python version
 import sys
 if sys.version_info < (2, 7):
-    print("Scrapy %s requires Python 2.7" % __version__)
+    print("Scrapy {0!s} requires Python 2.7".format(__version__))
     sys.exit(1)
 
 # Ignore noisy twisted deprecation warnings

--- a/scrapy/cmdline.py
+++ b/scrapy/cmdline.py
@@ -38,7 +38,7 @@ def _get_commands_from_entry_points(inproject, group='scrapy.commands'):
         if inspect.isclass(obj):
             cmds[entry_point.name] = obj()
         else:
-            raise Exception("Invalid entry point %s" % entry_point.name)
+            raise Exception("Invalid entry point {0!s}".format(entry_point.name))
     return cmds
 
 def _get_commands_dict(settings, inproject):
@@ -59,10 +59,10 @@ def _pop_command_name(argv):
 
 def _print_header(settings, inproject):
     if inproject:
-        print("Scrapy %s - project: %s\n" % (scrapy.__version__, \
+        print("Scrapy {0!s} - project: {1!s}\n".format(scrapy.__version__, \
             settings['BOT_NAME']))
     else:
-        print("Scrapy %s - no active project\n" % scrapy.__version__)
+        print("Scrapy {0!s} - no active project\n".format(scrapy.__version__))
 
 def _print_commands(settings, inproject):
     _print_header(settings, inproject)
@@ -71,7 +71,7 @@ def _print_commands(settings, inproject):
     print("Available commands:")
     cmds = _get_commands_dict(settings, inproject)
     for cmdname, cmdclass in sorted(cmds.items()):
-        print("  %-13s %s" % (cmdname, cmdclass.short_desc()))
+        print("  {0:<13!s} {1!s}".format(cmdname, cmdclass.short_desc()))
     if not inproject:
         print()
         print("  [ more ]      More commands available when run from project directory")
@@ -80,7 +80,7 @@ def _print_commands(settings, inproject):
 
 def _print_unknown_command(settings, cmdname, inproject):
     _print_header(settings, inproject)
-    print("Unknown command: %s\n" % cmdname)
+    print("Unknown command: {0!s}\n".format(cmdname))
     print('Use "scrapy" to see available commands')
 
 def _run_print_help(parser, func, *a, **kw):
@@ -130,7 +130,7 @@ def execute(argv=None, settings=None):
         sys.exit(2)
 
     cmd = cmds[cmdname]
-    parser.usage = "scrapy %s %s" % (cmdname, cmd.syntax())
+    parser.usage = "scrapy {0!s} {1!s}".format(cmdname, cmd.syntax())
     parser.description = cmd.long_desc()
     settings.setdict(cmd.default_settings, priority='command')
     cmd.settings = settings
@@ -150,7 +150,7 @@ def _run_command(cmd, args, opts):
 
 def _run_command_profiled(cmd, args, opts):
     if opts.profile:
-        sys.stderr.write("scrapy: writing cProfile stats to %r\n" % opts.profile)
+        sys.stderr.write("scrapy: writing cProfile stats to {0!r}\n".format(opts.profile))
     loc = locals()
     p = cProfile.Profile()
     p.runctx('cmd.run(args, opts)', globals(), loc)

--- a/scrapy/commands/__init__.py
+++ b/scrapy/commands/__init__.py
@@ -60,7 +60,7 @@ class ScrapyCommand(object):
         group.add_option("--logfile", metavar="FILE",
             help="log file. if omitted stderr will be used")
         group.add_option("-L", "--loglevel", metavar="LEVEL", default=None,
-            help="log level (default: %s)" % self.settings['LOG_LEVEL'])
+            help="log level (default: {0!s})".format(self.settings['LOG_LEVEL']))
         group.add_option("--nolog", action="store_true",
             help="disable logging completely")
         group.add_option("--profile", metavar="FILE", default=None,

--- a/scrapy/commands/check.py
+++ b/scrapy/commands/check.py
@@ -19,7 +19,7 @@ class TextTestResult(_TextTestResult):
         plural = "s" if run != 1 else ""
 
         writeln(self.separator2)
-        writeln("Ran %d contract%s in %.3fs" % (run, plural, stop - start))
+        writeln("Ran {0:d} contract{1!s} in {2:.3f}s".format(run, plural, stop - start))
         writeln()
 
         infos = []
@@ -27,14 +27,14 @@ class TextTestResult(_TextTestResult):
             write("FAILED")
             failed, errored = map(len, (self.failures, self.errors))
             if failed:
-                infos.append("failures=%d" % failed)
+                infos.append("failures={0:d}".format(failed))
             if errored:
-                infos.append("errors=%d" % errored)
+                infos.append("errors={0:d}".format(errored))
         else:
             write("OK")
 
         if infos:
-            writeln(" (%s)" % (", ".join(infos),))
+            writeln(" ({0!s})".format(", ".join(infos)))
         else:
             write("\n")
 
@@ -86,7 +86,7 @@ class Command(ScrapyCommand):
                     continue
                 print(spider)
                 for method in sorted(methods):
-                    print('  * %s' % method)
+                    print('  * {0!s}'.format(method))
         else:
             start = time.time()
             self.crawler_process.start()

--- a/scrapy/commands/edit.py
+++ b/scrapy/commands/edit.py
@@ -29,8 +29,8 @@ class Command(ScrapyCommand):
         try:
             spidercls = self.crawler_process.spider_loader.load(args[0])
         except KeyError:
-            return self._err("Spider not found: %s" % args[0])
+            return self._err("Spider not found: {0!s}".format(args[0]))
 
         sfile = sys.modules[spidercls.__module__].__file__
         sfile = sfile.replace('.pyc', '.py')
-        self.exitcode = os.system('%s "%s"' % (editor, sfile))
+        self.exitcode = os.system('{0!s} "{1!s}"'.format(editor, sfile))

--- a/scrapy/commands/genspider.py
+++ b/scrapy/commands/genspider.py
@@ -74,14 +74,14 @@ class Command(ScrapyCommand):
         else:
             # if spider already exists and not --force then halt
             if not opts.force:
-                print("Spider %r already exists in module:" % name)
-                print("  %s" % spidercls.__module__)
+                print("Spider {0!r} already exists in module:".format(name))
+                print("  {0!s}".format(spidercls.__module__))
                 return
         template_file = self._find_template(opts.template)
         if template_file:
             self._genspider(module, name, domain, opts.template, template_file)
             if opts.edit:
-                self.exitcode = os.system('scrapy edit "%s"' % name)
+                self.exitcode = os.system('scrapy edit "{0!s}"'.format(name))
 
     def _genspider(self, module, name, domain, template_name, template_file):
         """Generate the spider module, based on the given template"""
@@ -91,30 +91,30 @@ class Command(ScrapyCommand):
             'module': module,
             'name': name,
             'domain': domain,
-            'classname': '%sSpider' % ''.join(s.capitalize() \
-                for s in module.split('_'))
+            'classname': '{0!s}Spider'.format(''.join(s.capitalize() \
+                for s in module.split('_')))
         }
         spiders_module = import_module(self.settings['NEWSPIDER_MODULE'])
         spiders_dir = abspath(dirname(spiders_module.__file__))
-        spider_file = "%s.py" % join(spiders_dir, module)
+        spider_file = "{0!s}.py".format(join(spiders_dir, module))
         shutil.copyfile(template_file, spider_file)
         render_templatefile(spider_file, **tvars)
-        print("Created spider %r using template %r in module:" % (name, \
+        print("Created spider {0!r} using template {1!r} in module:".format(name, \
             template_name))
-        print("  %s.%s" % (spiders_module.__name__, module))
+        print("  {0!s}.{1!s}".format(spiders_module.__name__, module))
 
     def _find_template(self, template):
-        template_file = join(self.templates_dir, '%s.tmpl' % template)
+        template_file = join(self.templates_dir, '{0!s}.tmpl'.format(template))
         if exists(template_file):
             return template_file
-        print("Unable to find template: %s\n" % template)
+        print("Unable to find template: {0!s}\n".format(template))
         print('Use "scrapy genspider --list" to see all available templates.')
 
     def _list_templates(self):
         print("Available templates:")
         for filename in sorted(os.listdir(self.templates_dir)):
             if filename.endswith('.tmpl'):
-                print("  %s" % splitext(filename)[0])
+                print("  {0!s}".format(splitext(filename)[0]))
 
     @property
     def templates_dir(self):

--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -96,13 +96,13 @@ class Command(ScrapyCommand):
 
         if opts.verbose:
             for level in range(1, self.max_level+1):
-                print('\n>>> DEPTH LEVEL: %s <<<' % level)
+                print('\n>>> DEPTH LEVEL: {0!s} <<<'.format(level))
                 if not opts.noitems:
                     self.print_items(level, colour)
                 if not opts.nolinks:
                     self.print_requests(level, colour)
         else:
-            print('\n>>> STATUS DEPTH LEVEL %s <<<' % self.max_level)
+            print('\n>>> STATUS DEPTH LEVEL {0!s} <<<'.format(self.max_level))
             if not opts.noitems:
                 self.print_items(colour=colour)
             if not opts.nolinks:

--- a/scrapy/commands/runspider.py
+++ b/scrapy/commands/runspider.py
@@ -14,7 +14,7 @@ def _import_file(filepath):
     dirname, file = os.path.split(abspath)
     fname, fext = os.path.splitext(file)
     if fext != '.py':
-        raise ValueError("Not a Python source file: %s" % abspath)
+        raise ValueError("Not a Python source file: {0!s}".format(abspath))
     if dirname:
         sys.path = [dirname] + sys.path
     try:
@@ -74,14 +74,14 @@ class Command(ScrapyCommand):
             raise UsageError()
         filename = args[0]
         if not os.path.exists(filename):
-            raise UsageError("File not found: %s\n" % filename)
+            raise UsageError("File not found: {0!s}\n".format(filename))
         try:
             module = _import_file(filename)
         except (ImportError, ValueError) as e:
-            raise UsageError("Unable to load %r: %s\n" % (filename, e))
+            raise UsageError("Unable to load {0!r}: {1!s}\n".format(filename, e))
         spclasses = list(iter_spider_classes(module))
         if not spclasses:
-            raise UsageError("No spider found in file: %s\n" % filename)
+            raise UsageError("No spider found in file: {0!s}\n".format(filename))
         spidercls = spclasses.pop()
 
         self.crawler_process.crawl(spidercls, **opts.spargs)

--- a/scrapy/commands/startproject.py
+++ b/scrapy/commands/startproject.py
@@ -44,9 +44,9 @@ class Command(ScrapyCommand):
             print('Error: Project names must begin with a letter and contain'\
                     ' only\nletters, numbers and underscores')
         elif exists(project_name):
-            print('Error: Directory %r already exists' % project_name)
+            print('Error: Directory {0!r} already exists'.format(project_name))
         elif _module_exists(project_name):
-            print('Error: Module %r already exists' % project_name)
+            print('Error: Module {0!r} already exists'.format(project_name))
         else:
             return True
         return False
@@ -68,11 +68,10 @@ class Command(ScrapyCommand):
                 string.Template(path).substitute(project_name=project_name))
             render_templatefile(tplfile, project_name=project_name,
                 ProjectName=string_camelcase(project_name))
-        print("New Scrapy project %r, using template directory %r, created in:" % \
-              (project_name, self.templates_dir))
-        print("    %s\n" % abspath(project_name))
+        print("New Scrapy project {0!r}, using template directory {1!r}, created in:".format(project_name, self.templates_dir))
+        print("    {0!s}\n".format(abspath(project_name)))
         print("You can start your first spider with:")
-        print("    cd %s" % project_name)
+        print("    cd {0!s}".format(project_name))
         print("    scrapy genspider example example.com")
 
     @property

--- a/scrapy/commands/version.py
+++ b/scrapy/commands/version.py
@@ -29,15 +29,15 @@ class Command(ScrapyCommand):
             import lxml.etree
             lxml_version = ".".join(map(str, lxml.etree.LXML_VERSION))
             libxml2_version = ".".join(map(str, lxml.etree.LIBXML_VERSION))
-            print("Scrapy    : %s" % scrapy.__version__)
-            print("lxml      : %s" % lxml_version)
-            print("libxml2   : %s" % libxml2_version)
-            print("Twisted   : %s" % twisted.version.short())
-            print("Python    : %s" % sys.version.replace("\n", "- "))
-            print("pyOpenSSL : %s" % self._get_openssl_version())
-            print("Platform  : %s" % platform.platform())
+            print("Scrapy    : {0!s}".format(scrapy.__version__))
+            print("lxml      : {0!s}".format(lxml_version))
+            print("libxml2   : {0!s}".format(libxml2_version))
+            print("Twisted   : {0!s}".format(twisted.version.short()))
+            print("Python    : {0!s}".format(sys.version.replace("\n", "- ")))
+            print("pyOpenSSL : {0!s}".format(self._get_openssl_version()))
+            print("Platform  : {0!s}".format(platform.platform()))
         else:
-            print("Scrapy %s" % scrapy.__version__)
+            print("Scrapy {0!s}".format(scrapy.__version__))
 
     def _get_openssl_version(self):
         try:

--- a/scrapy/contracts/__init__.py
+++ b/scrapy/contracts/__init__.py
@@ -95,8 +95,8 @@ class Contract(object):
     """ Abstract class for contracts """
 
     def __init__(self, method, *args):
-        self.testcase_pre = _create_testcase(method, '@%s pre-hook' % self.name)
-        self.testcase_post = _create_testcase(method, '@%s post-hook' % self.name)
+        self.testcase_pre = _create_testcase(method, '@{0!s} pre-hook'.format(self.name))
+        self.testcase_post = _create_testcase(method, '@{0!s} post-hook'.format(self.name))
         self.args = args
 
     def add_pre_hook(self, request, results):
@@ -155,8 +155,8 @@ def _create_testcase(method, desc):
 
     class ContractTestCase(TestCase):
         def __str__(_self):
-            return "[%s] %s (%s)" % (spider, method.__name__, desc)
+            return "[{0!s}] {1!s} ({2!s})".format(spider, method.__name__, desc)
 
-    name = '%s_%s' % (spider, method.__name__)
+    name = '{0!s}_{1!s}'.format(spider, method.__name__)
     setattr(ContractTestCase, name, lambda x: x)
     return ContractTestCase(name)

--- a/scrapy/contracts/default.py
+++ b/scrapy/contracts/default.py
@@ -68,10 +68,9 @@ class ReturnsContract(Contract):
             if self.min_bound == self.max_bound:
                 expected = self.min_bound
             else:
-                expected = '%s..%s' % (self.min_bound, self.max_bound)
+                expected = '{0!s}..{1!s}'.format(self.min_bound, self.max_bound)
 
-            raise ContractFail("Returned %s %s, expected %s" % \
-                (occurrences, self.obj_name, expected))
+            raise ContractFail("Returned {0!s} {1!s}, expected {2!s}".format(occurrences, self.obj_name, expected))
 
 
 class ScrapesContract(Contract):
@@ -86,4 +85,4 @@ class ScrapesContract(Contract):
             if isinstance(x, (BaseItem, dict)):
                 for arg in self.args:
                     if not arg in x:
-                        raise ContractFail("'%s' field is missing" % arg)
+                        raise ContractFail("'{0!s}' field is missing".format(arg))

--- a/scrapy/core/downloader/__init__.py
+++ b/scrapy/core/downloader/__init__.py
@@ -44,7 +44,7 @@ class Slot(object):
 
     def __repr__(self):
         cls_name = self.__class__.__name__
-        return "%s(concurrency=%r, delay=%0.2f, randomize_delay=%r)" % (
+        return "{0!s}(concurrency={1!r}, delay={2:0.2f}, randomize_delay={3!r})".format(
             cls_name, self.concurrency, self.delay, self.randomize_delay)
 
     def __str__(self):
@@ -61,8 +61,7 @@ class Slot(object):
 def _get_concurrency_delay(concurrency, spider, settings):
     delay = settings.getfloat('DOWNLOAD_DELAY')
     if hasattr(spider, 'DOWNLOAD_DELAY'):
-        warnings.warn("%s.DOWNLOAD_DELAY attribute is deprecated, use %s.download_delay instead" %
-                      (type(spider).__name__, type(spider).__name__))
+        warnings.warn("{0!s}.DOWNLOAD_DELAY attribute is deprecated, use {1!s}.download_delay instead".format(type(spider).__name__, type(spider).__name__))
         delay = spider.DOWNLOAD_DELAY
     if hasattr(spider, 'download_delay'):
         delay = spider.download_delay

--- a/scrapy/core/downloader/handlers/__init__.py
+++ b/scrapy/core/downloader/handlers/__init__.py
@@ -60,8 +60,7 @@ class DownloadHandlers(object):
         scheme = urlparse_cached(request).scheme
         handler = self._get_handler(scheme)
         if not handler:
-            raise NotSupported("Unsupported URL scheme '%s': %s" %
-                               (scheme, self._notconfigured[scheme]))
+            raise NotSupported("Unsupported URL scheme '{0!s}': {1!s}".format(scheme, self._notconfigured[scheme]))
         return handler.download_request(request, spider)
 
     @defer.inlineCallbacks

--- a/scrapy/core/downloader/handlers/http11.py
+++ b/scrapy/core/downloader/handlers/http11.py
@@ -43,10 +43,10 @@ class HTTP11DownloadHandler(object):
             # use context factory defaults
             self._contextFactory = self._contextFactoryClass()
             msg = """
- '%s' does not accept `method` argument (type OpenSSL.SSL method,\
+ '{0!s}' does not accept `method` argument (type OpenSSL.SSL method,\
  e.g. OpenSSL.SSL.SSLv23_METHOD).\
- Please upgrade your context factory class to handle it or ignore it.""" % (
-                settings['DOWNLOADER_CLIENTCONTEXTFACTORY'],)
+ Please upgrade your context factory class to handle it or ignore it.""".format(
+                settings['DOWNLOADER_CLIENTCONTEXTFACTORY'])
             warnings.warn(msg)
         self._default_maxsize = settings.getint('DOWNLOAD_MAXSIZE')
         self._default_warnsize = settings.getint('DOWNLOAD_WARNSIZE')
@@ -281,7 +281,7 @@ class ScrapyAgent(object):
         if self._txresponse:
             self._txresponse._transport.stopProducing()
 
-        raise TimeoutError("Getting %s took longer than %s seconds." % (url, timeout))
+        raise TimeoutError("Getting {0!s} took longer than {1!s} seconds.".format(url, timeout))
 
     def _cb_latency(self, result, request, start_time):
         request.meta['download_latency'] = time() - start_time

--- a/scrapy/core/downloader/handlers/s3.py
+++ b/scrapy/core/downloader/handlers/s3.py
@@ -54,7 +54,7 @@ class S3DownloadHandler(object):
             import botocore.credentials
             kw.pop('anon', None)
             if kw:
-                raise TypeError('Unexpected keyword arguments: %s' % kw)
+                raise TypeError('Unexpected keyword arguments: {0!s}'.format(kw))
             if not self.anon:
                 SignerCls = botocore.auth.AUTH_TYPE_MAPS['s3']
                 self._signer = SignerCls(botocore.credentials.Credentials(
@@ -74,14 +74,14 @@ class S3DownloadHandler(object):
         scheme = 'https' if request.meta.get('is_secure') else 'http'
         bucket = p.hostname
         path = p.path + '?' + p.query if p.query else p.path
-        url = '%s://%s.s3.amazonaws.com%s' % (scheme, bucket, path)
+        url = '{0!s}://{1!s}.s3.amazonaws.com{2!s}'.format(scheme, bucket, path)
         if self.anon:
             request = request.replace(url=url)
         elif self._signer is not None:
             import botocore.awsrequest
             awsrequest = botocore.awsrequest.AWSRequest(
                 method=request.method,
-                url='%s://s3.amazonaws.com/%s%s' % (scheme, bucket, path),
+                url='{0!s}://s3.amazonaws.com/{1!s}{2!s}'.format(scheme, bucket, path),
                 headers=request.headers.to_unicode_dict(),
                 data=request.body)
             self._signer.add_auth(awsrequest)

--- a/scrapy/core/downloader/middleware.py
+++ b/scrapy/core/downloader/middleware.py
@@ -36,8 +36,7 @@ class DownloaderMiddlewareManager(MiddlewareManager):
             for method in self.methods['process_request']:
                 response = yield method(request=request, spider=spider)
                 assert response is None or isinstance(response, (Response, Request)), \
-                        'Middleware %s.process_request must return None, Response or Request, got %s' % \
-                        (six.get_method_self(method).__class__.__name__, response.__class__.__name__)
+                        'Middleware {0!s}.process_request must return None, Response or Request, got {1!s}'.format(six.get_method_self(method).__class__.__name__, response.__class__.__name__)
                 if response:
                     defer.returnValue(response)
             defer.returnValue((yield download_func(request=request,spider=spider)))
@@ -52,8 +51,7 @@ class DownloaderMiddlewareManager(MiddlewareManager):
                 response = yield method(request=request, response=response,
                                         spider=spider)
                 assert isinstance(response, (Response, Request)), \
-                    'Middleware %s.process_response must return Response or Request, got %s' % \
-                    (six.get_method_self(method).__class__.__name__, type(response))
+                    'Middleware {0!s}.process_response must return Response or Request, got {1!s}'.format(six.get_method_self(method).__class__.__name__, type(response))
                 if isinstance(response, Request):
                     defer.returnValue(response)
             defer.returnValue(response)
@@ -65,8 +63,7 @@ class DownloaderMiddlewareManager(MiddlewareManager):
                 response = yield method(request=request, exception=exception,
                                         spider=spider)
                 assert response is None or isinstance(response, (Response, Request)), \
-                    'Middleware %s.process_exception must return None, Response or Request, got %s' % \
-                    (six.get_method_self(method).__class__.__name__, type(response))
+                    'Middleware {0!s}.process_exception must return None, Response or Request, got {1!s}'.format(six.get_method_self(method).__class__.__name__, type(response))
                 if response:
                     defer.returnValue(response)
             defer.returnValue(_failure)

--- a/scrapy/core/downloader/webclient.py
+++ b/scrapy/core/downloader/webclient.py
@@ -89,8 +89,7 @@ class ScrapyHTTPPageGetter(HTTPClient):
             self.transport.stopProducing()
 
         self.factory.noPage(\
-                defer.TimeoutError("Getting %s took longer than %s seconds." % \
-                (self.factory.url, self.factory.timeout)))
+                defer.TimeoutError("Getting {0!s} took longer than {1!s} seconds.".format(self.factory.url, self.factory.timeout)))
 
 
 class ScrapyHTTPClientFactory(HTTPClientFactory):

--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -205,7 +205,7 @@ class ExecutionEngine(object):
 
     def crawl(self, request, spider):
         assert spider in self.open_spiders, \
-            "Spider %r not opened when crawling: %s" % (spider.name, request)
+            "Spider {0!r} not opened when crawling: {1!s}".format(spider.name, request)
         self.schedule(request, spider)
         self.slot.nextcall.schedule()
 
@@ -252,8 +252,8 @@ class ExecutionEngine(object):
 
     @defer.inlineCallbacks
     def open_spider(self, spider, start_requests=(), close_if_idle=True):
-        assert self.has_capacity(), "No free spider slot when opening %r" % \
-            spider.name
+        assert self.has_capacity(), "No free spider slot when opening {0!r}".format( \
+            spider.name)
         logger.info("Spider opened", extra={'spider': spider})
         nextcall = CallLaterOnce(self._next_request, spider)
         scheduler = self.scheduler_cls.from_crawler(self.crawler)

--- a/scrapy/core/scheduler.py
+++ b/scrapy/core/scheduler.py
@@ -106,7 +106,7 @@ class Scheduler(object):
         return self.mqclass()
 
     def _newdq(self, priority):
-        return self.dqclass(join(self.dqdir, 'p%s' % priority))
+        return self.dqclass(join(self.dqdir, 'p{0!s}'.format(priority)))
 
     def _dq(self):
         activef = join(self.dqdir, 'active.json')

--- a/scrapy/core/scraper.py
+++ b/scrapy/core/scraper.py
@@ -163,7 +163,7 @@ class Scraper(object):
             spider=spider
         )
         self.crawler.stats.inc_value(
-            "spider_exceptions/%s" % _failure.value.__class__.__name__,
+            "spider_exceptions/{0!s}".format(_failure.value.__class__.__name__),
             spider=spider
         )
 

--- a/scrapy/core/spidermw.py
+++ b/scrapy/core/spidermw.py
@@ -32,7 +32,7 @@ class SpiderMiddlewareManager(MiddlewareManager):
             self.methods['process_start_requests'].insert(0, mw.process_start_requests)
 
     def scrape_response(self, scrape_func, response, request, spider):
-        fname = lambda f:'%s.%s' % (
+        fname = lambda f:'{0!s}.{1!s}'.format(
                 six.get_method_self(f).__class__.__name__,
                 six.get_method_function(f).__name__)
 
@@ -53,8 +53,7 @@ class SpiderMiddlewareManager(MiddlewareManager):
             for method in self.methods['process_spider_exception']:
                 result = method(response=response, exception=exception, spider=spider)
                 assert result is None or _isiterable(result), \
-                    'Middleware %s must returns None, or an iterable object, got %s ' % \
-                    (fname(method), type(result))
+                    'Middleware {0!s} must returns None, or an iterable object, got {1!s} '.format(fname(method), type(result))
                 if result is not None:
                     return result
             return _failure
@@ -63,8 +62,7 @@ class SpiderMiddlewareManager(MiddlewareManager):
             for method in self.methods['process_spider_output']:
                 result = method(response=response, result=result, spider=spider)
                 assert _isiterable(result), \
-                    'Middleware %s must returns an iterable object, got %s ' % \
-                    (fname(method), type(result))
+                    'Middleware {0!s} must returns an iterable object, got {1!s} '.format(fname(method), type(result))
             return result
 
         dfd = mustbe_deferred(process_spider_input, response)

--- a/scrapy/downloadermiddlewares/cookies.py
+++ b/scrapy/downloadermiddlewares/cookies.py
@@ -71,12 +71,12 @@ class CookiesMiddleware(object):
 
     def _format_cookie(self, cookie):
         # build cookie string
-        cookie_str = '%s=%s' % (cookie['name'], cookie['value'])
+        cookie_str = '{0!s}={1!s}'.format(cookie['name'], cookie['value'])
 
         if cookie.get('path', None):
-            cookie_str += '; Path=%s' % cookie['path']
+            cookie_str += '; Path={0!s}'.format(cookie['path'])
         if cookie.get('domain', None):
-            cookie_str += '; Domain=%s' % cookie['domain']
+            cookie_str += '; Domain={0!s}'.format(cookie['domain'])
 
         return cookie_str
 

--- a/scrapy/downloadermiddlewares/httpcache.py
+++ b/scrapy/downloadermiddlewares/httpcache.py
@@ -52,7 +52,7 @@ class HttpCacheMiddleware(object):
             self.stats.inc_value('httpcache/miss', spider=spider)
             if self.ignore_missing:
                 self.stats.inc_value('httpcache/ignore', spider=spider)
-                raise IgnoreRequest("Ignored request not in cache: %s" % request)
+                raise IgnoreRequest("Ignored request not in cache: {0!s}".format(request))
             return  # first time request
 
         # Return cached response only if not expired

--- a/scrapy/downloadermiddlewares/httpproxy.py
+++ b/scrapy/downloadermiddlewares/httpproxy.py
@@ -34,7 +34,7 @@ class HttpProxyMiddleware(object):
 
         if user:
             user_pass = to_bytes(
-                '%s:%s' % (unquote(user), unquote(password)),
+                '{0!s}:{1!s}'.format(unquote(user), unquote(password)),
                 encoding=self.auth_encoding)
             creds = base64.b64encode(user_pass).strip()
         else:

--- a/scrapy/downloadermiddlewares/robotstxt.py
+++ b/scrapy/downloadermiddlewares/robotstxt.py
@@ -51,7 +51,7 @@ class RobotsTxtMiddleware(object):
 
         if netloc not in self._parsers:
             self._parsers[netloc] = Deferred()
-            robotsurl = "%s://%s/robots.txt" % (url.scheme, url.netloc)
+            robotsurl = "{0!s}://{1!s}/robots.txt".format(url.scheme, url.netloc)
             robotsreq = Request(
                 robotsurl,
                 priority=self.DOWNLOAD_PRIORITY,

--- a/scrapy/downloadermiddlewares/stats.py
+++ b/scrapy/downloadermiddlewares/stats.py
@@ -15,18 +15,18 @@ class DownloaderStats(object):
 
     def process_request(self, request, spider):
         self.stats.inc_value('downloader/request_count', spider=spider)
-        self.stats.inc_value('downloader/request_method_count/%s' % request.method, spider=spider)
+        self.stats.inc_value('downloader/request_method_count/{0!s}'.format(request.method), spider=spider)
         reqlen = len(request_httprepr(request))
         self.stats.inc_value('downloader/request_bytes', reqlen, spider=spider)
 
     def process_response(self, request, response, spider):
         self.stats.inc_value('downloader/response_count', spider=spider)
-        self.stats.inc_value('downloader/response_status_count/%s' % response.status, spider=spider)
+        self.stats.inc_value('downloader/response_status_count/{0!s}'.format(response.status), spider=spider)
         reslen = len(response_httprepr(response))
         self.stats.inc_value('downloader/response_bytes', reslen, spider=spider)
         return response
 
     def process_exception(self, request, exception, spider):
-        ex_class = "%s.%s" % (exception.__class__.__module__, exception.__class__.__name__)
+        ex_class = "{0!s}.{1!s}".format(exception.__class__.__module__, exception.__class__.__name__)
         self.stats.inc_value('downloader/exception_count', spider=spider)
-        self.stats.inc_value('downloader/exception_type_count/%s' % ex_class, spider=spider)
+        self.stats.inc_value('downloader/exception_type_count/{0!s}'.format(ex_class), spider=spider)

--- a/scrapy/exporters.py
+++ b/scrapy/exporters.py
@@ -37,7 +37,7 @@ class BaseItemExporter(object):
         self.export_empty_fields = options.pop('export_empty_fields', False)
         self.encoding = options.pop('encoding', 'utf-8')
         if not dont_fail and options:
-            raise TypeError("Unexpected options: %s" % ', '.join(options.keys()))
+            raise TypeError("Unexpected options: {0!s}".format(', '.join(options.keys())))
 
     def export_item(self, item):
         raise NotImplementedError

--- a/scrapy/extensions/corestats.py
+++ b/scrapy/extensions/corestats.py
@@ -36,4 +36,4 @@ class CoreStats(object):
     def item_dropped(self, item, spider, exception):
         reason = exception.__class__.__name__
         self.stats.inc_value('item_dropped_count', spider=spider)
-        self.stats.inc_value('item_dropped_reasons_count/%s' % reason, spider=spider)
+        self.stats.inc_value('item_dropped_reasons_count/{0!s}'.format(reason), spider=spider)

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -137,7 +137,7 @@ class FTPFeedStorage(BlockingFeedStorage):
         ftp.login(self.username, self.password)
         dirname, filename = posixpath.split(self.path)
         ftp_makedirs_cwd(ftp, dirname)
-        ftp.storbinary('STOR %s' % filename, file)
+        ftp.storbinary('STOR {0!s}'.format(filename), file)
         ftp.quit()
 
 

--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -217,7 +217,7 @@ class DbmCacheStorage(object):
         self.db = None
 
     def open_spider(self, spider):
-        dbpath = os.path.join(self.cachedir, '%s.db' % spider.name)
+        dbpath = os.path.join(self.cachedir, '{0!s}.db'.format(spider.name))
         self.db = self.dbmodule.open(dbpath, 'c')
 
     def close_spider(self, spider):
@@ -243,13 +243,13 @@ class DbmCacheStorage(object):
             'headers': dict(response.headers),
             'body': response.body,
         }
-        self.db['%s_data' % key] = pickle.dumps(data, protocol=2)
-        self.db['%s_time' % key] = str(time())
+        self.db['{0!s}_data'.format(key)] = pickle.dumps(data, protocol=2)
+        self.db['{0!s}_time'.format(key)] = str(time())
 
     def _read_data(self, spider, request):
         key = self._request_key(request)
         db = self.db
-        tkey = '%s_time' % key
+        tkey = '{0!s}_time'.format(key)
         if tkey not in db:
             return  # not found
 
@@ -257,7 +257,7 @@ class DbmCacheStorage(object):
         if 0 < self.expiration_secs < time() - float(ts):
             return  # expired
 
-        return pickle.loads(db['%s_data' % key])
+        return pickle.loads(db['{0!s}_data'.format(key)])
 
     def _request_key(self, request):
         return request_fingerprint(request)
@@ -345,7 +345,7 @@ class LeveldbCacheStorage(object):
         self.db = None
 
     def open_spider(self, spider):
-        dbpath = os.path.join(self.cachedir, '%s.leveldb' % spider.name)
+        dbpath = os.path.join(self.cachedir, '{0!s}.leveldb'.format(spider.name))
         self.db = self._leveldb.LevelDB(dbpath)
 
     def close_spider(self, spider):

--- a/scrapy/extensions/memdebug.py
+++ b/scrapy/extensions/memdebug.py
@@ -31,4 +31,4 @@ class MemoryDebugger(object):
         for cls, wdict in six.iteritems(live_refs):
             if not wdict:
                 continue
-            self.stats.set_value('memdebug/live_refs/%s' % cls.__name__, len(wdict), spider=spider)
+            self.stats.set_value('memdebug/live_refs/{0!s}'.format(cls.__name__), len(wdict), spider=spider)

--- a/scrapy/extensions/memusage.py
+++ b/scrapy/extensions/memusage.py
@@ -82,8 +82,7 @@ class MemoryUsage(object):
             logger.error("Memory usage exceeded %(memusage)dM. Shutting down Scrapy...",
                          {'memusage': mem}, extra={'crawler': self.crawler})
             if self.notify_mails:
-                subj = "%s terminated: memory usage exceeded %dM at %s" % \
-                        (self.crawler.settings['BOT_NAME'], mem, socket.gethostname())
+                subj = "{0!s} terminated: memory usage exceeded {1:d}M at {2!s}".format(self.crawler.settings['BOT_NAME'], mem, socket.gethostname())
                 self._send_report(self.notify_mails, subj)
                 self.crawler.stats.set_value('memusage/limit_notified', 1)
 
@@ -103,8 +102,7 @@ class MemoryUsage(object):
             logger.warning("Memory usage reached %(memusage)dM",
                            {'memusage': mem}, extra={'crawler': self.crawler})
             if self.notify_mails:
-                subj = "%s warning: memory usage reached %dM at %s" % \
-                        (self.crawler.settings['BOT_NAME'], mem, socket.gethostname())
+                subj = "{0!s} warning: memory usage reached {1:d}M at {2!s}".format(self.crawler.settings['BOT_NAME'], mem, socket.gethostname())
                 self._send_report(self.notify_mails, subj)
                 self.crawler.stats.set_value('memusage/warning_notified', 1)
             self.warned = True
@@ -112,9 +110,9 @@ class MemoryUsage(object):
     def _send_report(self, rcpts, subject):
         """send notification mail with some additional useful info"""
         stats = self.crawler.stats
-        s = "Memory usage at engine startup : %dM\r\n" % (stats.get_value('memusage/startup')/1024/1024)
-        s += "Maximum memory usage           : %dM\r\n" % (stats.get_value('memusage/max')/1024/1024)
-        s += "Current memory usage           : %dM\r\n" % (self.get_virtual_size()/1024/1024)
+        s = "Memory usage at engine startup : {0:d}M\r\n".format((stats.get_value('memusage/startup')/1024/1024))
+        s += "Maximum memory usage           : {0:d}M\r\n".format((stats.get_value('memusage/max')/1024/1024))
+        s += "Current memory usage           : {0:d}M\r\n".format((self.get_virtual_size()/1024/1024))
 
         s += "ENGINE STATUS ------------------------------------------------------- \r\n"
         s += "\r\n"

--- a/scrapy/extensions/statsmailer.py
+++ b/scrapy/extensions/statsmailer.py
@@ -28,7 +28,7 @@ class StatsMailer(object):
     def spider_closed(self, spider):
         spider_stats = self.stats.get_stats(spider)
         body = "Global stats\n\n"
-        body += "\n".join("%-50s : %s" % i for i in self.stats.get_stats().items())
-        body += "\n\n%s stats\n\n" % spider.name
-        body += "\n".join("%-50s : %s" % i for i in spider_stats.items())
-        return self.mail.send(self.recipients, "Scrapy stats for: %s" % spider.name, body)
+        body += "\n".join("{0:<50!s} : {1!s}".format(*i) for i in self.stats.get_stats().items())
+        body += "\n\n{0!s} stats\n\n".format(spider.name)
+        body += "\n".join("{0:<50!s} : {1!s}".format(*i) for i in spider_stats.items())
+        return self.mail.send(self.recipients, "Scrapy stats for: {0!s}".format(spider.name), body)

--- a/scrapy/http/common.py
+++ b/scrapy/http/common.py
@@ -1,6 +1,6 @@
 def obsolete_setter(setter, attrname):
     def newsetter(self, value):
         c = self.__class__.__name__
-        msg = "%s.%s is not modifiable, use %s.replace() instead" % (c, attrname, c)
+        msg = "{0!s}.{1!s} is not modifiable, use {2!s}.replace() instead".format(c, attrname, c)
         raise AttributeError(msg)
     return newsetter

--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -24,7 +24,7 @@ class Request(object_ref):
         self.method = str(method).upper()
         self._set_url(url)
         self._set_body(body)
-        assert isinstance(priority, int), "Request priority not an integer: %r" % priority
+        assert isinstance(priority, int), "Request priority not an integer: {0!r}".format(priority)
         self.priority = priority
 
         assert callback or not errback, "Cannot use errback without a callback"
@@ -48,13 +48,13 @@ class Request(object_ref):
 
     def _set_url(self, url):
         if not isinstance(url, six.string_types):
-            raise TypeError('Request url must be str or unicode, got %s:' % type(url).__name__)
+            raise TypeError('Request url must be str or unicode, got {0!s}:'.format(type(url).__name__))
 
         url = to_native_str(url, self.encoding)
         self._url = escape_ajax(safe_url_string(url))
 
         if ':' not in self._url:
-            raise ValueError('Missing scheme in request url: %s' % self._url)
+            raise ValueError('Missing scheme in request url: {0!s}'.format(self._url))
 
     url = property(_get_url, obsolete_setter(_set_url, 'url'))
 
@@ -74,7 +74,7 @@ class Request(object_ref):
         return self._encoding
 
     def __str__(self):
-        return "<%s %s>" % (self.method, self.url)
+        return "<{0!s} {1!s}>".format(self.method, self.url)
 
     __repr__ = __str__
 

--- a/scrapy/http/request/form.py
+++ b/scrapy/http/request/form.py
@@ -68,15 +68,15 @@ def _get_form(response, formname, formid, formnumber, formxpath):
                             base_url=get_base_url(response))
     forms = root.xpath('//form')
     if not forms:
-        raise ValueError("No <form> element found in %s" % response)
+        raise ValueError("No <form> element found in {0!s}".format(response))
 
     if formname is not None:
-        f = root.xpath('//form[@name="%s"]' % formname)
+        f = root.xpath('//form[@name="{0!s}"]'.format(formname))
         if f:
             return f[0]
 
     if formid is not None:
-        f = root.xpath('//form[@id="%s"]' % formid)
+        f = root.xpath('//form[@id="{0!s}"]'.format(formid))
         if f:
             return f[0]
 
@@ -92,7 +92,7 @@ def _get_form(response, formname, formid, formnumber, formxpath):
                 if el is None:
                     break
         encoded = formxpath if six.PY3 else formxpath.encode('unicode_escape')
-        raise ValueError('No <form> element found with %s' % encoded)
+        raise ValueError('No <form> element found with {0!s}'.format(encoded))
 
     # If we get here, it means that either formname was None
     # or invalid
@@ -100,8 +100,7 @@ def _get_form(response, formname, formid, formnumber, formxpath):
         try:
             form = forms[formnumber]
         except IndexError:
-            raise IndexError("Form number %d not found in %s" %
-                             (formnumber, response))
+            raise IndexError("Form number {0:d} not found in {1!s}".format(formnumber, response))
         else:
             return form
 
@@ -192,7 +191,7 @@ def _get_clickable(clickdata, form):
     # We didn't find it, so now we build an XPath expression out of the other
     # arguments, because they can be used as such
     xpath = u'.//*' + \
-            u''.join(u'[@%s="%s"]' % c for c in six.iteritems(clickdata))
+            u''.join(u'[@{0!s}="{1!s}"]'.format(*c) for c in six.iteritems(clickdata))
     el = form.xpath(xpath)
     if len(el) == 1:
         return (el[0].get('name'), el[0].get('value') or '')
@@ -200,4 +199,4 @@ def _get_clickable(clickdata, form):
         raise ValueError("Multiple elements found (%r) matching the criteria "
                          "in clickdata: %r" % (el, clickdata))
     else:
-        raise ValueError('No clickable element matching clickdata: %r' % (clickdata,))
+        raise ValueError('No clickable element matching clickdata: {0!r}'.format(clickdata))

--- a/scrapy/http/response/__init__.py
+++ b/scrapy/http/response/__init__.py
@@ -37,7 +37,7 @@ class Response(object_ref):
         if isinstance(url, str):
             self._url = url
         else:
-            raise TypeError('%s url must be str, got %s:' % (type(self).__name__,
+            raise TypeError('{0!s} url must be str, got {1!s}:'.format(type(self).__name__,
                 type(url).__name__))
 
     url = property(_get_url, obsolete_setter(_set_url, 'url'))
@@ -59,7 +59,7 @@ class Response(object_ref):
     body = property(_get_body, obsolete_setter(_set_body, 'body'))
 
     def __str__(self):
-        return "<%d %s>" % (self.status, self.url)
+        return "<{0:d} {1!s}>".format(self.status, self.url)
 
     __repr__ = __str__
 

--- a/scrapy/http/response/text.py
+++ b/scrapy/http/response/text.py
@@ -39,8 +39,8 @@ class TextResponse(Response):
         self._body = b''  # used by encoding detection
         if isinstance(body, six.text_type):
             if self._encoding is None:
-                raise TypeError('Cannot convert unicode body - %s has no encoding' %
-                    type(self).__name__)
+                raise TypeError('Cannot convert unicode body - {0!s} has no encoding'.format(
+                    type(self).__name__))
             self._body = body.encode(self._encoding)
         else:
             super(TextResponse, self)._set_body(body)
@@ -68,7 +68,7 @@ class TextResponse(Response):
         # _body_inferred_encoding is called
         benc = self.encoding
         if self._cached_ubody is None:
-            charset = 'charset=%s' % benc
+            charset = 'charset={0!s}'.format(benc)
             self._cached_ubody = html_to_unicode(charset, self.body)[1]
         return self._cached_ubody
 

--- a/scrapy/item.py
+++ b/scrapy/item.py
@@ -59,21 +59,19 @@ class DictItem(MutableMapping, BaseItem):
         if key in self.fields:
             self._values[key] = value
         else:
-            raise KeyError("%s does not support field: %s" %
-                (self.__class__.__name__, key))
+            raise KeyError("{0!s} does not support field: {1!s}".format(self.__class__.__name__, key))
 
     def __delitem__(self, key):
         del self._values[key]
 
     def __getattr__(self, name):
         if name in self.fields:
-            raise AttributeError("Use item[%r] to get field value" % name)
+            raise AttributeError("Use item[{0!r}] to get field value".format(name))
         raise AttributeError(name)
 
     def __setattr__(self, name, value):
         if not name.startswith('_'):
-            raise AttributeError("Use item[%r] = %r to set field value" %
-                (name, value))
+            raise AttributeError("Use item[{0!r}] = {1!r} to set field value".format(name, value))
         super(DictItem, self).__setattr__(name, value)
 
     def __len__(self):

--- a/scrapy/link.py
+++ b/scrapy/link.py
@@ -23,7 +23,7 @@ class Link(object):
                 url = to_bytes(url, encoding='utf8')
             else:
                 got = url.__class__.__name__
-                raise TypeError("Link urls must be str objects, got %s" % got)
+                raise TypeError("Link urls must be str objects, got {0!s}".format(got))
         self.url = url
         self.text = text
         self.fragment = fragment
@@ -37,6 +37,5 @@ class Link(object):
         return hash(self.url) ^ hash(self.text) ^ hash(self.fragment) ^ hash(self.nofollow)
 
     def __repr__(self):
-        return 'Link(url=%r, text=%r, fragment=%r, nofollow=%r)' % \
-            (self.url, self.text, self.fragment, self.nofollow)
+        return 'Link(url={0!r}, text={1!r}, fragment={2!r}, nofollow={3!r})'.format(self.url, self.text, self.fragment, self.nofollow)
 

--- a/scrapy/loader/__init__.py
+++ b/scrapy/loader/__init__.py
@@ -124,21 +124,20 @@ class ItemLoader(object):
         try:
             return proc(self._values[field_name])
         except Exception as e:
-            raise ValueError("Error with output processor: field=%r value=%r error='%s: %s'" % \
-                (field_name, self._values[field_name], type(e).__name__, str(e)))
+            raise ValueError("Error with output processor: field={0!r} value={1!r} error='{2!s}: {3!s}'".format(field_name, self._values[field_name], type(e).__name__, str(e)))
 
     def get_collected_values(self, field_name):
         return self._values[field_name]
 
     def get_input_processor(self, field_name):
-        proc = getattr(self, '%s_in' % field_name, None)
+        proc = getattr(self, '{0!s}_in'.format(field_name), None)
         if not proc:
             proc = self._get_item_field_attr(field_name, 'input_processor', \
                 self.default_input_processor)
         return proc
 
     def get_output_processor(self, field_name):
-        proc = getattr(self, '%s_out' % field_name, None)
+        proc = getattr(self, '{0!s}_out'.format(field_name), None)
         if not proc:
             proc = self._get_item_field_attr(field_name, 'output_processor', \
                 self.default_output_processor)

--- a/scrapy/logformatter.py
+++ b/scrapy/logformatter.py
@@ -32,7 +32,7 @@ class LogFormatter(object):
     """
 
     def crawled(self, request, response, spider):
-        flags = ' %s' % str(response.flags) if response.flags else ''
+        flags = ' {0!s}'.format(str(response.flags)) if response.flags else ''
         return {
             'level': logging.DEBUG,
             'msg': CRAWLEDMSG,

--- a/scrapy/mail.py
+++ b/scrapy/mail.py
@@ -66,8 +66,7 @@ class MailSender(object):
                 part = MIMEBase(*mimetype.split('/'))
                 part.set_payload(f.read())
                 Encoders.encode_base64(part)
-                part.add_header('Content-Disposition', 'attachment; filename="%s"' \
-                    % attach_name)
+                part.add_header('Content-Disposition', 'attachment; filename="{0!s}"'.format(attach_name))
                 msg.attach(part)
         else:
             msg.set_payload(body)

--- a/scrapy/pipelines/files.py
+++ b/scrapy/pipelines/files.py
@@ -124,7 +124,7 @@ class S3FilesStore(object):
         return c.get_bucket(self.bucket, validate=False)
 
     def _get_boto_key(self, path):
-        key_name = '%s%s' % (self.prefix, path)
+        key_name = '{0!s}{1!s}'.format(self.prefix, path)
         if self.is_botocore:
             return threads.deferToThread(
                 self.s3_client.head_object,
@@ -136,7 +136,7 @@ class S3FilesStore(object):
 
     def persist_file(self, path, buf, info, meta=None, headers=None):
         """Upload file to S3 storage"""
-        key_name = '%s%s' % (self.prefix, path)
+        key_name = '{0!s}{1!s}'.format(self.prefix, path)
         buf.seek(0)
         if self.is_botocore:
             extra = self._headers_to_botocore_kwargs(self.HEADERS)
@@ -187,7 +187,7 @@ class S3FilesStore(object):
                 kwarg = mapping[key]
             except KeyError:
                 raise TypeError(
-                    'Header "%s" is not supported by botocore' % key)
+                    'Header "{0!s}" is not supported by botocore'.format(key))
             else:
                 extra[kwarg] = value
         return extra
@@ -355,7 +355,7 @@ class FilesPipeline(MediaPipeline):
 
     def inc_stats(self, spider, status):
         spider.crawler.stats.inc_value('file_count', spider=spider)
-        spider.crawler.stats.inc_value('file_status_count/%s' % status, spider=spider)
+        spider.crawler.stats.inc_value('file_status_count/{0!s}'.format(status), spider=spider)
 
     ### Overridable Interface
     def get_media_requests(self, item, info):
@@ -397,7 +397,7 @@ class FilesPipeline(MediaPipeline):
 
         media_guid = hashlib.sha1(to_bytes(url)).hexdigest()  # change to request.url after deprecation
         media_ext = os.path.splitext(url)[1]  # change to request.url after deprecation
-        return 'full/%s%s' % (media_guid, media_ext)
+        return 'full/{0!s}{1!s}'.format(media_guid, media_ext)
 
     # deprecated
     def file_key(self, url):

--- a/scrapy/pipelines/images.py
+++ b/scrapy/pipelines/images.py
@@ -79,8 +79,7 @@ class ImagesPipeline(FilesPipeline):
 
         width, height = orig_image.size
         if width < self.MIN_WIDTH or height < self.MIN_HEIGHT:
-            raise ImageException("Image too small (%dx%d < %dx%d)" %
-                                 (width, height, self.MIN_WIDTH, self.MIN_HEIGHT))
+            raise ImageException("Image too small ({0:d}x{1:d} < {2:d}x{3:d})".format(width, height, self.MIN_WIDTH, self.MIN_HEIGHT))
 
         image, buf = self.convert_image(orig_image)
         yield path, image, buf
@@ -140,7 +139,7 @@ class ImagesPipeline(FilesPipeline):
         ## end of deprecation warning block
 
         image_guid = hashlib.sha1(to_bytes(url)).hexdigest()  # change to request.url after deprecation
-        return 'full/%s.jpg' % (image_guid)
+        return 'full/{0!s}.jpg'.format((image_guid))
 
     def thumb_path(self, request, thumb_id, response=None, info=None):
         ## start of deprecation warning block (can be removed in the future)
@@ -165,7 +164,7 @@ class ImagesPipeline(FilesPipeline):
         ## end of deprecation warning block
 
         thumb_guid = hashlib.sha1(to_bytes(url)).hexdigest()  # change to request.url after deprecation
-        return 'thumbs/%s/%s.jpg' % (thumb_id, thumb_guid)
+        return 'thumbs/{0!s}/{1!s}.jpg'.format(thumb_id, thumb_guid)
 
     # deprecated
     def file_key(self, url):

--- a/scrapy/responsetypes.py
+++ b/scrapy/responsetypes.py
@@ -46,7 +46,7 @@ class ResponseTypes(object):
         elif mimetype in self.classes:
             return self.classes[mimetype]
         else:
-            basetype = "%s/*" % mimetype.split('/')[0]
+            basetype = "{0!s}/*".format(mimetype.split('/')[0])
             return self.classes.get(basetype, Response)
 
     def from_content_type(self, content_type, content_encoding=None):

--- a/scrapy/settings/__init__.py
+++ b/scrapy/settings/__init__.py
@@ -485,7 +485,7 @@ class CrawlerSettings(Settings):
         return Settings.__getitem__(self, opt_name)
 
     def __str__(self):
-        return "<CrawlerSettings module=%r>" % self.settings_module
+        return "<CrawlerSettings module={0!r}>".format(self.settings_module)
 
 CrawlerSettings = create_deprecated_class(
     'CrawlerSettings', CrawlerSettings,

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -261,7 +261,7 @@ TEMPLATES_DIR = abspath(join(dirname(__file__), '..', 'templates'))
 
 URLLENGTH_LIMIT = 2083
 
-USER_AGENT = 'Scrapy/%s (+http://scrapy.org)' % import_module('scrapy').__version__
+USER_AGENT = 'Scrapy/{0!s} (+http://scrapy.org)'.format(import_module('scrapy').__version__)
 
 TELNETCONSOLE_ENABLED = 1
 TELNETCONSOLE_PORT = [6023, 6073]

--- a/scrapy/settings/deprecated.py
+++ b/scrapy/settings/deprecated.py
@@ -22,5 +22,5 @@ def check_deprecated_settings(settings):
     if deprecated:
         msg = "You are using the following settings which are deprecated or obsolete"
         msg += " (ask scrapy-users@googlegroups.com for alternatives):"
-        msg = msg + "\n    " + "\n    ".join("%s: %s" % x for x in deprecated)
+        msg = msg + "\n    " + "\n    ".join("{0!s}: {1!s}".format(*x) for x in deprecated)
         warnings.warn(msg, ScrapyDeprecationWarning)

--- a/scrapy/shell.py
+++ b/scrapy/shell.py
@@ -138,7 +138,7 @@ class Shell(object):
         b.append("Available Scrapy objects:")
         for k, v in sorted(self.vars.items()):
             if self._is_relevant(v):
-                b.append("  %-10s %s" % (k, v))
+                b.append("  {0:<10!s} {1!s}".format(k, v))
         b.append("Useful shortcuts:")
         b.append("  shelp()           Shell help (print this help)")
         if self.inthread:
@@ -146,7 +146,7 @@ class Shell(object):
                      "update local objects")
         b.append("  view(response)    View response in a browser")
 
-        return "\n".join("[s] %s" % l for l in b)
+        return "\n".join("[s] {0!s}".format(l) for l in b)
 
     def _is_relevant(self, value):
         return isinstance(value, self.relevant_classes)

--- a/scrapy/spidermiddlewares/depth.py
+++ b/scrapy/spidermiddlewares/depth.py
@@ -43,7 +43,7 @@ class DepthMiddleware(object):
                     return False
                 elif self.stats:
                     if self.verbose_stats:
-                        self.stats.inc_value('request_depth_count/%s' % depth,
+                        self.stats.inc_value('request_depth_count/{0!s}'.format(depth),
                                              spider=spider)
                     self.stats.max_value('request_depth_max', depth,
                                          spider=spider)

--- a/scrapy/spidermiddlewares/offsite.py
+++ b/scrapy/spidermiddlewares/offsite.py
@@ -52,7 +52,7 @@ class OffsiteMiddleware(object):
         allowed_domains = getattr(spider, 'allowed_domains', None)
         if not allowed_domains:
             return re.compile('') # allow all by default
-        regex = r'^(.*\.)?(%s)$' % '|'.join(re.escape(d) for d in allowed_domains if d is not None)
+        regex = r'^(.*\.)?({0!s})$'.format('|'.join(re.escape(d) for d in allowed_domains if d is not None))
         return re.compile(regex)
 
     def spider_opened(self, spider):

--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -26,7 +26,7 @@ class Spider(object_ref):
         if name is not None:
             self.name = name
         elif not getattr(self, 'name', None):
-            raise ValueError("%s must have a name" % type(self).__name__)
+            raise ValueError("{0!s} must have a name".format(type(self).__name__))
         self.__dict__.update(kwargs)
         if not hasattr(self, 'start_urls'):
             self.start_urls = []
@@ -90,7 +90,7 @@ class Spider(object_ref):
             return closed(reason)
 
     def __str__(self):
-        return "<%s %r at 0x%0x>" % (type(self).__name__, self.name, id(self))
+        return "<{0!s} {1!r} at 0x{2:0x}>".format(type(self).__name__, self.name, id(self))
 
     __repr__ = __str__
 

--- a/scrapy/spiders/feed.py
+++ b/scrapy/spiders/feed.py
@@ -71,11 +71,11 @@ class XMLFeedSpider(Spider):
         elif self.iterator == 'xml':
             selector = Selector(response, type='xml')
             self._register_namespaces(selector)
-            nodes = selector.xpath('//%s' % self.itertag)
+            nodes = selector.xpath('//{0!s}'.format(self.itertag))
         elif self.iterator == 'html':
             selector = Selector(response, type='html')
             self._register_namespaces(selector)
-            nodes = selector.xpath('//%s' % self.itertag)
+            nodes = selector.xpath('//{0!s}'.format(self.itertag))
         else:
             raise NotSupported('Unsupported node iterator')
 

--- a/scrapy/utils/datatypes.py
+++ b/scrapy/utils/datatypes.py
@@ -49,7 +49,7 @@ class MultiValueDict(dict):
         dict.__init__(self, key_to_list_mapping)
 
     def __repr__(self):
-        return "<%s: %s>" % (self.__class__.__name__, dict.__repr__(self))
+        return "<{0!s}: {1!s}>".format(self.__class__.__name__, dict.__repr__(self))
 
     def __getitem__(self, key):
         """
@@ -59,7 +59,7 @@ class MultiValueDict(dict):
         try:
             list_ = dict.__getitem__(self, key)
         except KeyError:
-            raise MultiValueDictKeyError("Key %r not found in %r" % (key, self))
+            raise MultiValueDictKeyError("Key {0!r} not found in {1!r}".format(key, self))
         try:
             return list_[-1]
         except IndexError:
@@ -137,7 +137,7 @@ class MultiValueDict(dict):
     def update(self, *args, **kwargs):
         "update() extends rather than replaces existing key lists. Also accepts keyword args."
         if len(args) > 1:
-            raise TypeError("update expected at most 1 arguments, got %d" % len(args))
+            raise TypeError("update expected at most 1 arguments, got {0:d}".format(len(args)))
         if args:
             other_dict = args[0]
             if isinstance(other_dict, MultiValueDict):
@@ -174,10 +174,10 @@ class SiteNode(object):
         node.parent = self
 
     def to_string(self, level=0):
-        s = "%s%s\n" % ('  '*level, self.url)
+        s = "{0!s}{1!s}\n".format('  '*level, self.url)
         if self.itemnames:
             for n in self.itemnames:
-                s += "%sScraped: %s\n" % ('  '*(level+1), n)
+                s += "{0!s}Scraped: {1!s}\n".format('  '*(level+1), n)
         for node in self.children:
             s += node.to_string(level+1)
         return s

--- a/scrapy/utils/decorators.py
+++ b/scrapy/utils/decorators.py
@@ -14,9 +14,9 @@ def deprecated(use_instead=None):
     def deco(func):
         @wraps(func)
         def wrapped(*args, **kwargs):
-            message = "Call to deprecated function %s." % func.__name__
+            message = "Call to deprecated function {0!s}.".format(func.__name__)
             if use_instead:
-                message += " Use %s instead." % use_instead
+                message += " Use {0!s} instead.".format(use_instead)
             warnings.warn(message, category=ScrapyDeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
         return wrapped

--- a/scrapy/utils/deprecate.py
+++ b/scrapy/utils/deprecate.py
@@ -112,7 +112,7 @@ def create_deprecated_class(name, new_class, clsdict=None,
         # deprecated class is in jinja2 template). __module__ attribute is not
         # important enough to raise an exception as users may be unable
         # to fix inspect.stack() errors.
-        warnings.warn("Error detecting parent module: %r" % e)
+        warnings.warn("Error detecting parent module: {0!r}".format(e))
 
     return deprecated_cls
 

--- a/scrapy/utils/engine.py
+++ b/scrapy/utils/engine.py
@@ -28,7 +28,7 @@ def get_engine_status(engine):
         try:
             checks += [(test, eval(test))]
         except Exception as e:
-            checks += [(test, "%s (exception)" % type(e).__name__)]
+            checks += [(test, "{0!s} (exception)".format(type(e).__name__))]
 
     return checks
 
@@ -36,7 +36,7 @@ def format_engine_status(engine=None):
     checks = get_engine_status(engine)
     s = "Execution engine status\n\n"
     for test, result in checks:
-        s += "%-47s : %s\n" % (test, result)
+        s += "{0:<47!s} : {1!s}\n".format(test, result)
     s += "\n"
 
     return s

--- a/scrapy/utils/iterators.py
+++ b/scrapy/utils/iterators.py
@@ -26,8 +26,8 @@ def xmliter(obj, nodename):
     """
     nodename_patt = re.escape(nodename)
 
-    HEADER_START_RE = re.compile(r'^(.*?)<\s*%s(?:\s|>)' % nodename_patt, re.S)
-    HEADER_END_RE = re.compile(r'<\s*/%s\s*>' % nodename_patt, re.S)
+    HEADER_START_RE = re.compile(r'^(.*?)<\s*{0!s}(?:\s|>)'.format(nodename_patt), re.S)
+    HEADER_END_RE = re.compile(r'<\s*/{0!s}\s*>'.format(nodename_patt), re.S)
     text = _body_or_str(obj)
 
     header_start = re.search(HEADER_START_RE, text)
@@ -35,7 +35,7 @@ def xmliter(obj, nodename):
     header_end = re_rsearch(HEADER_END_RE, text)
     header_end = text[header_end[1]:].strip() if header_end else ''
 
-    r = re.compile(r'<%(np)s[\s>].*?</%(np)s>' % {'np': nodename_patt}, re.DOTALL)
+    r = re.compile(r'<{np!s}[\s>].*?</{np!s}>'.format(**{'np': nodename_patt}), re.DOTALL)
     for match in r.finditer(text):
         nodetext = header_start + match.group() + header_end
         yield Selector(text=nodetext, type='xml').xpath('//' + nodename)[0]
@@ -44,9 +44,9 @@ def xmliter(obj, nodename):
 def xmliter_lxml(obj, nodename, namespace=None, prefix='x'):
     from lxml import etree
     reader = _StreamReader(obj)
-    tag = '{%s}%s' % (namespace, nodename) if namespace else nodename
+    tag = '{{{0!s}}}{1!s}'.format(namespace, nodename) if namespace else nodename
     iterable = etree.iterparse(reader, tag=tag, encoding=reader.encoding)
-    selxpath = '//' + ('%s:%s' % (prefix, nodename) if namespace else nodename)
+    selxpath = '//' + ('{0!s}:{1!s}'.format(prefix, nodename) if namespace else nodename)
     for _, node in iterable:
         nodetext = etree.tostring(node, encoding='unicode')
         node.clear()
@@ -130,7 +130,7 @@ def csviter(obj, delimiter=None, headers=None, encoding=None, quotechar=None):
 def _body_or_str(obj, unicode=True):
     expected_types = (Response, six.text_type, six.binary_type)
     assert isinstance(obj, expected_types), \
-        "obj must be %s, not %s" % (
+        "obj must be {0!s}, not {1!s}".format(
             " or ".join(t.__name__ for t in expected_types),
             type(obj).__name__)
     if isinstance(obj, Response):

--- a/scrapy/utils/misc.py
+++ b/scrapy/utils/misc.py
@@ -38,7 +38,7 @@ def load_object(path):
     try:
         dot = path.rindex('.')
     except ValueError:
-        raise ValueError("Error loading object '%s': not a full path" % path)
+        raise ValueError("Error loading object '{0!s}': not a full path".format(path))
 
     module, name = path[:dot], path[dot+1:]
     mod = import_module(module)
@@ -46,7 +46,7 @@ def load_object(path):
     try:
         obj = getattr(mod, name)
     except AttributeError:
-        raise NameError("Module '%s' doesn't define any object named '%s'" % (module, name))
+        raise NameError("Module '{0!s}' doesn't define any object named '{1!s}'".format(module, name))
 
     return obj
 

--- a/scrapy/utils/project.py
+++ b/scrapy/utils/project.py
@@ -18,7 +18,7 @@ def inside_project():
         try:
             import_module(scrapy_module)
         except ImportError as exc:
-            warnings.warn("Cannot import scrapy settings module %s: %s" % (scrapy_module, exc))
+            warnings.warn("Cannot import scrapy settings module {0!s}: {1!s}".format(scrapy_module, exc))
         else:
             return True
     return bool(closest_scrapy_cfg())

--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -183,7 +183,7 @@ def isbinarytext(text):
     otherwise, by looking for binary bytes at their chars
     """
     if not isinstance(text, bytes):
-        raise TypeError("text must be bytes, got '%s'" % type(text).__name__)
+        raise TypeError("text must be bytes, got '{0!s}'".format(type(text).__name__))
     return any(c in _BINARYCHARS for c in text)
 
 
@@ -208,7 +208,7 @@ def get_func_args(func, stripself=False):
         else:
             return get_func_args(func.__call__, True)
     else:
-        raise TypeError('%s is not callable' % type(func))
+        raise TypeError('{0!s} is not callable'.format(type(func)))
     if stripself:
         func_args.pop(0)
     return func_args
@@ -241,7 +241,7 @@ def get_spec(func):
     elif hasattr(func, '__call__'):
         spec = inspect.getargspec(func.__call__)
     else:
-        raise TypeError('%s is not callable' % type(func))
+        raise TypeError('{0!s} is not callable'.format(type(func)))
 
     defaults = spec.defaults or []
 

--- a/scrapy/utils/reactor.py
+++ b/scrapy/utils/reactor.py
@@ -2,7 +2,7 @@ from twisted.internet import reactor, error
 
 def listen_tcp(portrange, host, factory):
     """Like reactor.listenTCP but tries different ports in a range."""
-    assert len(portrange) <= 2, "invalid portrange: %s" % portrange
+    assert len(portrange) <= 2, "invalid portrange: {0!s}".format(portrange)
     if not hasattr(portrange, '__iter__'):
         return reactor.listenTCP(portrange, factory, interface=host)
     if not portrange:

--- a/scrapy/utils/reqser.py
+++ b/scrapy/utils/reqser.py
@@ -70,7 +70,7 @@ def _find_method(obj, func):
         else:
             if func_self is obj:
                 return six.get_method_function(func).__name__
-    raise ValueError("Function %s is not a method of: %s" % (func, obj))
+    raise ValueError("Function {0!s} is not a method of: {1!s}".format(func, obj))
 
 
 def _get_method(obj, name):
@@ -78,4 +78,4 @@ def _get_method(obj, name):
     try:
         return getattr(obj, name)
     except AttributeError:
-        raise ValueError("Method %r not found in: %s" % (name, obj))
+        raise ValueError("Method {0!r} not found in: {1!s}".format(name, obj))

--- a/scrapy/utils/response.py
+++ b/scrapy/utils/response.py
@@ -54,7 +54,7 @@ def response_status_message(status):
     >>> response_status_message(404)
     '404 Not Found'
     """
-    return '%s %s' % (status, to_native_str(http.RESPONSES.get(int(status))))
+    return '{0!s} {1!s}'.format(status, to_native_str(http.RESPONSES.get(int(status))))
 
 
 def response_httprepr(response):
@@ -80,15 +80,15 @@ def open_in_browser(response, _openfunc=webbrowser.open):
     body = response.body
     if isinstance(response, HtmlResponse):
         if b'<base' not in body:
-            repl = '<head><base href="%s">' % response.url
+            repl = '<head><base href="{0!s}">'.format(response.url)
             body = body.replace(b'<head>', to_bytes(repl))
         ext = '.html'
     elif isinstance(response, TextResponse):
         ext = '.txt'
     else:
-        raise TypeError("Unsupported response type: %s" %
-                        response.__class__.__name__)
+        raise TypeError("Unsupported response type: {0!s}".format(
+                        response.__class__.__name__))
     fd, fname = tempfile.mkstemp(ext)
     os.write(fd, body)
     os.close(fd)
-    return _openfunc("file://%s" % fname)
+    return _openfunc("file://{0!s}".format(fname))

--- a/scrapy/utils/serialize.py
+++ b/scrapy/utils/serialize.py
@@ -15,7 +15,7 @@ class ScrapyJSONEncoder(json.JSONEncoder):
 
     def default(self, o):
         if isinstance(o, datetime.datetime):
-            return o.strftime("%s %s" % (self.DATE_FORMAT, self.TIME_FORMAT))
+            return o.strftime("{0!s} {1!s}".format(self.DATE_FORMAT, self.TIME_FORMAT))
         elif isinstance(o, datetime.date):
             return o.strftime(self.DATE_FORMAT)
         elif isinstance(o, datetime.time):
@@ -27,9 +27,9 @@ class ScrapyJSONEncoder(json.JSONEncoder):
         elif isinstance(o, BaseItem):
             return dict(o)
         elif isinstance(o, Request):
-            return "<%s %s %s>" % (type(o).__name__, o.method, o.url)
+            return "<{0!s} {1!s} {2!s}>".format(type(o).__name__, o.method, o.url)
         elif isinstance(o, Response):
-            return "<%s %s %s>" % (type(o).__name__, o.status, o.url)
+            return "<{0!s} {1!s} {2!s}>".format(type(o).__name__, o.status, o.url)
         else:
             return super(ScrapyJSONEncoder, self).default(o)
 

--- a/scrapy/utils/testproc.py
+++ b/scrapy/utils/testproc.py
@@ -23,10 +23,10 @@ class ProcessTest(object):
 
     def _process_finished(self, pp, cmd, check_code):
         if pp.exitcode and check_code:
-            msg = "process %s exit with code %d" % (cmd, pp.exitcode)
-            msg += "\n>>> stdout <<<\n%s" % pp.out
+            msg = "process {0!s} exit with code {1:d}".format(cmd, pp.exitcode)
+            msg += "\n>>> stdout <<<\n{0!s}".format(pp.out)
             msg += "\n"
-            msg += "\n>>> stderr <<<\n%s" % pp.err
+            msg += "\n>>> stderr <<<\n{0!s}".format(pp.err)
             raise RuntimeError(msg)
         return pp.exitcode, pp.out, pp.err
 

--- a/scrapy/utils/testsite.py
+++ b/scrapy/utils/testsite.py
@@ -10,7 +10,7 @@ class SiteTest(object):
     def setUp(self):
         super(SiteTest, self).setUp()
         self.site = reactor.listenTCP(0, test_site(), interface="127.0.0.1")
-        self.baseurl = "http://localhost:%d/" % self.site.getHost().port
+        self.baseurl = "http://localhost:{0:d}/".format(self.site.getHost().port)
 
     def tearDown(self):
         super(SiteTest, self).tearDown()
@@ -32,5 +32,5 @@ def test_site():
 
 if __name__ == '__main__':
     port = reactor.listenTCP(0, test_site(), interface="127.0.0.1")
-    print("http://localhost:%d/" % port.getHost().port)
+    print("http://localhost:{0:d}/".format(port.getHost().port))
     reactor.run()

--- a/scrapy/utils/trackref.py
+++ b/scrapy/utils/trackref.py
@@ -44,7 +44,7 @@ def format_live_refs(ignore=NoneType):
         if issubclass(cls, ignore):
             continue
         oldest = min(six.itervalues(wdict))
-        s += "%-30s %6d   oldest: %ds ago\n" % (
+        s += "{0:<30!s} {1:6d}   oldest: {2:d}s ago\n".format(
             cls.__name__, len(wdict), now - oldest
         )
     return s

--- a/scrapy/utils/url.py
+++ b/scrapy/utils/url.py
@@ -24,7 +24,7 @@ def url_is_from_any_domain(url, domains):
     if not host:
         return False
     domains = [d.lower() for d in domains]
-    return any((host == d) or (host.endswith('.%s' % d)) for d in domains)
+    return any((host == d) or (host.endswith('.{0!s}'.format(d))) for d in domains)
 
 
 def url_is_from_spider(url, spider):

--- a/scrapy/xlib/tx/_newclient.py
+++ b/scrapy/xlib/tx/_newclient.py
@@ -191,8 +191,8 @@ def _callAppFunction(function):
     try:
         function()
     except:
-        log.err(None, "Unexpected exception from %s" % (
-                fullyQualifiedName(function),))
+        log.err(None, "Unexpected exception from {0!s}".format(
+                fullyQualifiedName(function)))
 
 
 
@@ -584,13 +584,13 @@ class Request:
         # weren't limited to issuing HTTP/1.1 requests.
         requestLines = []
         requestLines.append(
-            '%s %s HTTP/1.1\r\n' % (self.method, self.uri))
+            '{0!s} {1!s} HTTP/1.1\r\n'.format(self.method, self.uri))
         if not self.persistent:
             requestLines.append('Connection: close\r\n')
         if TEorCL is not None:
             requestLines.append(TEorCL)
         for name, values in self.headers.getAllRawHeaders():
-            requestLines.extend(['%s: %s\r\n' % (name, v) for v in values])
+            requestLines.extend(['{0!s}: {1!s}\r\n'.format(name, v) for v in values])
         requestLines.append('\r\n')
         transport.writeSequence(requestLines)
 
@@ -626,7 +626,7 @@ class Request:
         """
         self._writeHeaders(
             transport,
-            'Content-Length: %d\r\n' % (self.bodyProducer.length,))
+            'Content-Length: {0:d}\r\n'.format(self.bodyProducer.length))
 
         # This Deferred is used to signal an error in the data written to the
         # encoder below.  It can only errback and it will only do so before too
@@ -859,7 +859,7 @@ def makeStatefulDispatcher(name, template):
         func = getattr(self, '_' + name + '_' + self._state, None)
         if func is None:
             raise RuntimeError(
-                "%r has no %s method in state %s" % (self, name, self._state))
+                "{0!r} has no {1!s} method in state {2!s}".format(self, name, self._state))
         return func(*args, **kwargs)
     dispatcher.__doc__ = template.__doc__
     return dispatcher
@@ -1120,7 +1120,7 @@ class ChunkedEncoder:
         """
         if self.transport is None:
             raise ExcessWrite()
-        self.transport.writeSequence(("%x\r\n" % len(data), data, "\r\n"))
+        self.transport.writeSequence(("{0:x}\r\n".format(len(data)), data, "\r\n"))
 
 
     def unregisterProducer(self):

--- a/scrapy/xlib/tx/client.py
+++ b/scrapy/xlib/tx/client.py
@@ -560,7 +560,7 @@ class _AgentBase(object):
         """
         if (scheme, port) in (('http', 80), ('https', 443)):
             return host
-        return '%s:%d' % (host, port)
+        return '{0!s}:{1:d}'.format(host, port)
 
 
     def _requestWithEndpoint(self, key, endpoint, method, parsedURI,
@@ -663,7 +663,7 @@ class Agent(_AgentBase):
                                       self._wrapContextFactory(host, port),
                                       **kwargs)
         else:
-            raise SchemeNotSupported("Unsupported scheme: %r" % (scheme,))
+            raise SchemeNotSupported("Unsupported scheme: {0!r}".format(scheme))
 
 
     def request(self, method, uri, headers=None, bodyProducer=None):

--- a/scrapy/xlib/tx/endpoints.py
+++ b/scrapy/xlib/tx/endpoints.py
@@ -905,7 +905,7 @@ def _parseServer(description, factory, default=None):
         for plugin in getPlugins(IStreamServerEndpointStringParser):
             if plugin.prefix == endpointType:
                 return (plugin, args[1:], kw)
-        raise ValueError("Unknown endpoint type: '%s'" % (endpointType,))
+        raise ValueError("Unknown endpoint type: '{0!s}'".format(endpointType))
     return (endpointType.upper(),) + parser(factory, *args[1:], **kw)
 
 
@@ -1242,7 +1242,7 @@ def clientFromString(reactor, description):
         if plugin.prefix.upper() == name:
             return plugin.parseStreamClient(*args, **kwargs)
     if name not in _clientParsers:
-        raise ValueError("Unknown endpoint type: %r" % (aname,))
+        raise ValueError("Unknown endpoint type: {0!r}".format(aname))
     kwargs = _clientParsers[name](*args, **kwargs)
     return _endpointClientFactories[name](reactor, **kwargs)
 

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -78,7 +78,7 @@ class Follow(LeafResource):
         for nl in nlist:
             args[b"n"] = [to_bytes(str(nl))]
             argstr = urlencode(args, doseq=True)
-            s += "<a href='/follow?%s'>follow %d</a><br>" % (argstr, nl)
+            s += "<a href='/follow?{0!s}'>follow {1:d}</a><br>".format(argstr, nl)
         s += """</body>"""
         request.write(to_bytes(s))
         request.finish()
@@ -96,7 +96,7 @@ class Delay(LeafResource):
         return NOT_DONE_YET
 
     def _delayedRender(self, request, n):
-        request.write(to_bytes("Response delayed for %0.3f seconds\n" % n))
+        request.write(to_bytes("Response delayed for {0:0.3f} seconds\n".format(n)))
         request.finish()
 
 
@@ -221,7 +221,7 @@ if __name__ == "__main__":
     def print_listening():
         httpHost = httpPort.getHost()
         httpsHost = httpsPort.getHost()
-        print("Mock server running at http://%s:%d and https://%s:%d" % (
+        print("Mock server running at http://{0!s}:{1:d} and https://{2!s}:{3:d}".format(
             httpHost.host, httpHost.port, httpsHost.host, httpsHost.port))
     reactor.callWhenRunning(print_listening)
     reactor.run()

--- a/tests/spiders.py
+++ b/tests/spiders.py
@@ -33,7 +33,7 @@ class FollowAllSpider(MetaSpider):
         self.urls_visited = []
         self.times = []
         qargs = {'total': total, 'show': show, 'order': order, 'maxlatency': maxlatency}
-        url = "http://localhost:8998/follow?%s" % urlencode(qargs, doseq=1)
+        url = "http://localhost:8998/follow?{0!s}".format(urlencode(qargs, doseq=1))
         self.start_urls = [url]
 
     def parse(self, response):
@@ -55,7 +55,7 @@ class DelaySpider(MetaSpider):
 
     def start_requests(self):
         self.t1 = time.time()
-        url = "http://localhost:8998/delay?n=%s&b=%s" % (self.n, self.b)
+        url = "http://localhost:8998/delay?n={0!s}&b={1!s}".format(self.n, self.b)
         yield Request(url, callback=self.parse, errback=self.errback)
 
     def parse(self, response):
@@ -74,7 +74,7 @@ class SimpleSpider(MetaSpider):
         self.start_urls = [url]
 
     def parse(self, response):
-        self.logger.info("Got response %d" % response.status)
+        self.logger.info("Got response {0:d}".format(response.status))
 
 
 class ItemSpider(FollowAllSpider):
@@ -121,7 +121,7 @@ class BrokenStartRequestsSpider(FollowAllSpider):
 
         for s in range(100):
             qargs = {'total': 10, 'seed': s}
-            url = "http://localhost:8998/follow?%s" % urlencode(qargs, doseq=1)
+            url = "http://localhost:8998/follow?{0!s}".format(urlencode(qargs, doseq=1))
             yield Request(url, meta={'seed': s})
             if self.fail_yielding:
                 2 / 0
@@ -169,7 +169,7 @@ class DuplicateStartRequestsSpider(Spider):
     def start_requests(self):
         for i in range(0, self.distinct_urls):
             for j in range(0, self.dupe_factor):
-                url = "http://localhost:8998/echo?headers=1&body=test%d" % i
+                url = "http://localhost:8998/echo?headers=1&body=test{0:d}".format(i)
                 yield self.make_requests_from_url(url)
 
     def make_requests_from_url(self, url):

--- a/tests/test_cmdline/extensions.py
+++ b/tests/test_cmdline/extensions.py
@@ -3,7 +3,7 @@
 class TestExtension(object):
 
     def __init__(self, settings):
-        settings.set('TEST1', "%s + %s" % (settings['TEST1'], 'started'))
+        settings.set('TEST1', "{0!s} + {1!s}".format(settings['TEST1'], 'started'))
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/tests/test_command_version.py
+++ b/tests/test_command_version.py
@@ -16,7 +16,7 @@ class VersionTest(ProcessTest, unittest.TestCase):
         _, out, _ = yield self.execute([])
         self.assertEqual(
             out.strip().decode(encoding),
-            "Scrapy %s" % scrapy.__version__,
+            "Scrapy {0!s}".format(scrapy.__version__),
         )
 
     @defer.inlineCallbacks

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -87,10 +87,10 @@ class StartprojectTemplatesTest(ProjectTest):
             pass
         assert exists(join(self.tmpl_proj, 'root_template'))
 
-        args = ['--set', 'TEMPLATES_DIR=%s' % self.tmpl]
+        args = ['--set', 'TEMPLATES_DIR={0!s}'.format(self.tmpl)]
         p = self.proc('startproject', self.project_name, *args)
         out = to_native_str(retry_on_eintr(p.stdout.read))
-        self.assertIn("New Scrapy project %r, using template directory" % self.project_name, out)
+        self.assertIn("New Scrapy project {0!r}, using template directory".format(self.project_name), out)
         self.assertIn(self.tmpl_proj, out)
         assert exists(join(self.proj_path, 'root_template'))
 
@@ -101,7 +101,7 @@ class CommandTest(ProjectTest):
         super(CommandTest, self).setUp()
         self.call('startproject', self.project_name)
         self.cwd = join(self.temp_path, self.project_name)
-        self.env['SCRAPY_SETTINGS_MODULE'] = '%s.settings' % self.project_name
+        self.env['SCRAPY_SETTINGS_MODULE'] = '{0!s}.settings'.format(self.project_name)
 
 
 class GenspiderCommandTest(CommandTest):
@@ -115,15 +115,15 @@ class GenspiderCommandTest(CommandTest):
         assert exists(join(self.proj_mod_path, 'spiders', 'test_name.py'))
 
     def test_template(self, tplname='crawl'):
-        args = ['--template=%s' % tplname] if tplname else []
+        args = ['--template={0!s}'.format(tplname)] if tplname else []
         spname = 'test_spider'
         p = self.proc('genspider', spname, 'test.com', *args)
         out = to_native_str(retry_on_eintr(p.stdout.read))
-        self.assertIn("Created spider %r using template %r in module" % (spname, tplname), out)
+        self.assertIn("Created spider {0!r} using template {1!r} in module".format(spname, tplname), out)
         self.assertTrue(exists(join(self.proj_mod_path, 'spiders', 'test_spider.py')))
         p = self.proc('genspider', spname, 'test.com', *args)
         out = to_native_str(retry_on_eintr(p.stdout.read))
-        self.assertIn("Spider %r already exists in module" % spname, out)
+        self.assertIn("Spider {0!r} already exists in module".format(spname), out)
 
     def test_template_basic(self):
         self.test_template('basic')
@@ -143,7 +143,7 @@ class GenspiderCommandTest(CommandTest):
 
     def test_same_name_as_project(self):
         self.assertEqual(2, self.call('genspider', self.project_name))
-        assert not exists(join(self.proj_mod_path, 'spiders', '%s.py' % self.project_name))
+        assert not exists(join(self.proj_mod_path, 'spiders', '{0!s}.py'.format(self.project_name)))
 
 
 class MiscCommandsTest(CommandTest):
@@ -255,8 +255,8 @@ class MyPipeline(object):
         fname = abspath(join(self.proj_mod_path, 'settings.py'))
         with open(fname, 'a') as f:
             f.write("""
-ITEM_PIPELINES = {'%s.pipelines.MyPipeline': 1}
-""" % self.project_name)
+ITEM_PIPELINES = {{'{0!s}.pipelines.MyPipeline': 1}}
+""".format(self.project_name))
 
     @defer.inlineCallbacks
     def test_spider_arguments(self):

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -50,7 +50,7 @@ class CrawlTestCase(TestCase):
         avgd = totaltime / (len(t) - 1)
         tolerance = 0.6 if randomize else 0.2
         self.assertTrue(avgd > delay * (1 - tolerance),
-                        "download delay too small: %s" % avgd)
+                        "download delay too small: {0!s}".format(avgd))
 
     @defer.inlineCallbacks
     def test_timeout_success(self):

--- a/tests/test_downloader_handlers.py
+++ b/tests/test_downloader_handlers.py
@@ -100,7 +100,7 @@ class FileTestCase(unittest.TestCase):
         return self.download_request(request, Spider('foo')).addCallback(_test)
 
     def test_non_existent(self):
-        request = Request('file://%s' % self.mktemp())
+        request = Request('file://{0!s}'.format(self.mktemp()))
         d = self.download_request(request, Spider('foo'))
         return self.assertFailure(d, IOError)
 
@@ -151,7 +151,7 @@ class HttpTestCase(unittest.TestCase):
             yield self.download_handler.close()
 
     def getURL(self, path):
-        return "%s://%s:%d/%s" % (self.scheme, self.host, self.portno, path)
+        return "{0!s}://{1!s}:{2:d}/{3!s}".format(self.scheme, self.host, self.portno, path)
 
     def test_download(self):
         request = Request(self.getURL('file'))
@@ -202,7 +202,7 @@ class HttpTestCase(unittest.TestCase):
     def test_host_header_not_in_request_headers(self):
         def _test(response):
             self.assertEquals(
-                response.body, to_bytes('%s:%d' % (self.host, self.portno)))
+                response.body, to_bytes('{0!s}:{1:d}'.format(self.host, self.portno)))
             self.assertEquals(request.headers, {})
 
         request = Request(self.getURL('host'))
@@ -405,7 +405,7 @@ class HttpProxyTestCase(unittest.TestCase):
             yield self.download_handler.close()
 
     def getURL(self, path):
-        return "http://127.0.0.1:%d/%s" % (self.portno, path)
+        return "http://127.0.0.1:{0:d}/{1!s}".format(self.portno, path)
 
     def test_download_with_proxy(self):
         def _test(response):
@@ -423,7 +423,7 @@ class HttpProxyTestCase(unittest.TestCase):
             self.assertEquals(response.url, request.url)
             self.assertEquals(response.body, b'https://example.com')
 
-        http_proxy = '%s?noconnect' % self.getURL('')
+        http_proxy = '{0!s}?noconnect'.format(self.getURL(''))
         request = Request('https://example.com', meta={'proxy': http_proxy})
         return self.download_request(request, Spider('foo')).addCallback(_test)
 
@@ -682,7 +682,7 @@ class FTPTestCase(unittest.TestCase):
         return deferred
 
     def test_ftp_download_success(self):
-        request = Request(url="ftp://127.0.0.1:%s/file.txt" % self.portNum,
+        request = Request(url="ftp://127.0.0.1:{0!s}/file.txt".format(self.portNum),
                 meta={"ftp_user": self.username, "ftp_password": self.password})
         d = self.download_handler.download_request(request, None)
 
@@ -694,7 +694,7 @@ class FTPTestCase(unittest.TestCase):
 
     def test_ftp_download_path_with_spaces(self):
         request = Request(
-            url="ftp://127.0.0.1:%s/file with spaces.txt" % self.portNum,
+            url="ftp://127.0.0.1:{0!s}/file with spaces.txt".format(self.portNum),
             meta={"ftp_user": self.username, "ftp_password": self.password}
         )
         d = self.download_handler.download_request(request, None)
@@ -706,7 +706,7 @@ class FTPTestCase(unittest.TestCase):
         return self._add_test_callbacks(d, _test)
 
     def test_ftp_download_notexist(self):
-        request = Request(url="ftp://127.0.0.1:%s/notexist.txt" % self.portNum,
+        request = Request(url="ftp://127.0.0.1:{0!s}/notexist.txt".format(self.portNum),
                 meta={"ftp_user": self.username, "ftp_password": self.password})
         d = self.download_handler.download_request(request, None)
 
@@ -716,7 +716,7 @@ class FTPTestCase(unittest.TestCase):
 
     def test_ftp_local_filename(self):
         local_fname = "/tmp/file.txt"
-        request = Request(url="ftp://127.0.0.1:%s/file.txt" % self.portNum,
+        request = Request(url="ftp://127.0.0.1:{0!s}/file.txt".format(self.portNum),
                 meta={"ftp_user": self.username, "ftp_password": self.password, "ftp_local_filename": local_fname})
         d = self.download_handler.download_request(request, None)
 
@@ -732,7 +732,7 @@ class FTPTestCase(unittest.TestCase):
     def test_invalid_credentials(self):
         from twisted.protocols.ftp import ConnectionLost
 
-        request = Request(url="ftp://127.0.0.1:%s/file.txt" % self.portNum,
+        request = Request(url="ftp://127.0.0.1:{0!s}/file.txt".format(self.portNum),
                 meta={"ftp_user": self.username, "ftp_password": 'invalid'})
         d = self.download_handler.download_request(request, None)
 

--- a/tests/test_downloadermiddleware_decompression.py
+++ b/tests/test_downloadermiddleware_decompression.py
@@ -29,7 +29,7 @@ class DecompressionMiddlewareTest(TestCase):
             rsp = self.test_responses[fmt]
             new = self.mw.process_response(None, rsp, self.spider)
             assert isinstance(new, XmlResponse), \
-                    'Failed %s, response type %s' % (fmt, type(new).__name__)
+                    'Failed {0!s}, response type {1!s}'.format(fmt, type(new).__name__)
             assert_samelines(self, new.body, self.uncompressed_body, fmt)
 
     def test_plain_response(self):

--- a/tests/test_downloadermiddleware_httpcache.py
+++ b/tests/test_downloadermiddleware_httpcache.py
@@ -329,7 +329,7 @@ class RFC2616PolicyTest(DefaultStorageTest):
         ]
         with self._middleware() as mw:
             for idx, (shouldcache, status, headers) in enumerate(responses):
-                req0 = Request('http://example-%d.com' % idx)
+                req0 = Request('http://example-{0:d}.com'.format(idx))
                 res0 = Response(req0.url, status=status, headers=headers)
                 res1 = self._process_requestresponse(mw, req0, res0)
                 res304 = res0.replace(status=304)
@@ -348,7 +348,7 @@ class RFC2616PolicyTest(DefaultStorageTest):
         with self._middleware(HTTPCACHE_ALWAYS_STORE=True) as mw:
             for idx, (_, status, headers) in enumerate(responses):
                 shouldcache = 'no-store' not in headers.get('Cache-Control', '') and status != 304
-                req0 = Request('http://example2-%d.com' % idx)
+                req0 = Request('http://example2-{0:d}.com'.format(idx))
                 res0 = Response(req0.url, status=status, headers=headers)
                 res1 = self._process_requestresponse(mw, req0, res0)
                 res304 = res0.replace(status=304)
@@ -391,7 +391,7 @@ class RFC2616PolicyTest(DefaultStorageTest):
         ]
         with self._middleware() as mw:
             for idx, (status, headers) in enumerate(sampledata):
-                req0 = Request('http://example-%d.com' % idx)
+                req0 = Request('http://example-{0:d}.com'.format(idx))
                 res0 = Response(req0.url, status=status, headers=headers)
                 # cache fresh response
                 res1 = self._process_requestresponse(mw, req0, res0)
@@ -428,7 +428,7 @@ class RFC2616PolicyTest(DefaultStorageTest):
         ]
         with self._middleware() as mw:
             for idx, (status, headers) in enumerate(sampledata):
-                req0 = Request('http://example-%d.com' % idx)
+                req0 = Request('http://example-{0:d}.com'.format(idx))
                 res0a = Response(req0.url, status=status, headers=headers)
                 # cache expired response
                 res1 = self._process_requestresponse(mw, req0, res0a)
@@ -495,7 +495,7 @@ class RFC2616PolicyTest(DefaultStorageTest):
         ]
         with self._middleware(HTTPCACHE_IGNORE_RESPONSE_CACHE_CONTROLS=['no-cache', 'no-store']) as mw:
             for idx, (status, headers) in enumerate(sampledata):
-                req0 = Request('http://example-%d.com' % idx)
+                req0 = Request('http://example-{0:d}.com'.format(idx))
                 res0 = Response(req0.url, status=status, headers=headers)
                 # cache fresh response
                 res1 = self._process_requestresponse(mw, req0, res0)

--- a/tests/test_downloadermiddleware_redirect.py
+++ b/tests/test_downloadermiddleware_redirect.py
@@ -77,7 +77,7 @@ class RedirectMiddlewareTest(unittest.TestCase):
         assert 'Content-Length' not in req2.headers, \
             "Content-Length header must not be present in redirected request"
         assert not req2.body, \
-            "Redirected body must be empty, not '%s'" % req2.body
+            "Redirected body must be empty, not '{0!s}'".format(req2.body)
 
         # response without Location header but with status code is 3XX should be ignored
         del rsp.headers['Location']
@@ -216,7 +216,7 @@ class MetaRefreshMiddlewareTest(unittest.TestCase):
         assert 'Content-Length' not in req2.headers, \
             "Content-Length header must not be present in redirected request"
         assert not req2.body, \
-            "Redirected body must be empty, not '%s'" % req2.body
+            "Redirected body must be empty, not '{0!s}'".format(req2.body)
 
     def test_max_redirect_times(self):
         self.mw.max_redirect_times = 1

--- a/tests/test_downloadermiddleware_retry.py
+++ b/tests/test_downloadermiddleware_retry.py
@@ -79,7 +79,7 @@ class RetryTest(unittest.TestCase):
             exceptions.append(ResponseFailed)
 
         for exc in exceptions:
-            req = Request('http://www.scrapytest.org/%s' % exc.__name__)
+            req = Request('http://www.scrapytest.org/{0!s}'.format(exc.__name__))
             self._test_retry_exception(req, exc('foo'))
 
     def _test_retry_exception(self, req, exception):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -82,8 +82,7 @@ def start_test_site(debug=False):
 
     port = reactor.listenTCP(0, server.Site(r), interface="127.0.0.1")
     if debug:
-        print("Test server running at http://localhost:%d/ - hit Ctrl-C to finish." \
-            % port.getHost().port)
+        print("Test server running at http://localhost:{0:d}/ - hit Ctrl-C to finish.".format(port.getHost().port))
     return port
 
 
@@ -130,7 +129,7 @@ class CrawlerRun(object):
         self.deferred.callback(None)
 
     def geturl(self, path):
-        return "http://localhost:%s%s" % (self.portno, path)
+        return "http://localhost:{0!s}{1!s}".format(self.portno, path)
 
     def getpath(self, url):
         u = urlparse(url)
@@ -180,7 +179,7 @@ class EngineTest(unittest.TestCase):
                            "/item1.html", "/item2.html", "/item999.html"]
         urls_visited = set([rp[0].url for rp in self.run.respplug])
         urls_expected = set([self.run.geturl(p) for p in must_be_visited])
-        assert urls_expected <= urls_visited, "URLs not visited: %s" % list(urls_expected - urls_visited)
+        assert urls_expected <= urls_visited, "URLs not visited: {0!s}".format(list(urls_expected - urls_visited))
 
     def _assert_scheduled_requests(self, urls_to_visit=None):
         self.assertEqual(urls_to_visit, len(self.run.reqplug))

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -12,7 +12,7 @@ class CustomItem(Item):
     name = Field()
 
     def __str__(self):
-        return "name: %s" % self['name']
+        return "name: {0!s}".format(self['name'])
 
 
 class LoggingContribTest(unittest.TestCase):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -48,7 +48,7 @@ class TestMiddlewareManager(MiddlewareManager):
 
     @classmethod
     def _get_mwlist_from_settings(cls, settings):
-        return ['tests.test_middleware.%s' % x for x in ['M1', 'MOff', 'M3']]
+        return ['tests.test_middleware.{0!s}'.format(x) for x in ['M1', 'MOff', 'M3']]
 
     def _add_middleware(self, mw):
         super(TestMiddlewareManager, self)._add_middleware(mw)

--- a/tests/test_pipeline_files.py
+++ b/tests/test_pipeline_files.py
@@ -110,7 +110,7 @@ class DeprecatedFilesPipeline(FilesPipeline):
     def file_key(self, url):
         media_guid = hashlib.sha1(to_bytes(url)).hexdigest()
         media_ext = os.path.splitext(url)[1]
-        return 'empty/%s%s' % (media_guid, media_ext)
+        return 'empty/{0!s}{1!s}'.format(media_guid, media_ext)
 
 
 class DeprecatedFilesPipelineTestCase(unittest.TestCase):

--- a/tests/test_pipeline_images.py
+++ b/tests/test_pipeline_images.py
@@ -102,11 +102,11 @@ class DeprecatedImagesPipeline(ImagesPipeline):
 
     def image_key(self, url):
         image_guid = hashlib.sha1(to_bytes(url)).hexdigest()
-        return 'empty/%s.jpg' % (image_guid)
+        return 'empty/{0!s}.jpg'.format((image_guid))
 
     def thumb_key(self, url, thumb_id):
         thumb_guid = hashlib.sha1(to_bytes(url)).hexdigest()
-        return 'thumbsup/%s/%s.jpg' % (thumb_id, thumb_guid)
+        return 'thumbsup/{0!s}/{1!s}.jpg'.format(thumb_id, thumb_guid)
 
 
 class DeprecatedImagesPipelineTestCase(unittest.TestCase):

--- a/tests/test_proxy_connect.py
+++ b/tests/test_proxy_connect.py
@@ -101,7 +101,7 @@ class ProxyConnectTestCase(TestCase):
         self._assert_got_response_code(407, l)
 
     def _assert_got_response_code(self, code, log):
-        self.assertEqual(str(log).count('Crawled (%d)' % code), 1)
+        self.assertEqual(str(log).count('Crawled ({0:d})'.format(code)), 1)
 
     def _assert_got_tunnel_error(self, log):
         self.assertEqual(str(log).count('TunnelError'), 1)

--- a/tests/test_responsetypes.py
+++ b/tests/test_responsetypes.py
@@ -17,7 +17,7 @@ class ResponseTypesTest(unittest.TestCase):
         ]
         for source, cls in mappings:
             retcls = responsetypes.from_filename(source)
-            assert retcls is cls, "%s ==> %s != %s" % (source, retcls, cls)
+            assert retcls is cls, "{0!s} ==> {1!s} != {2!s}".format(source, retcls, cls)
 
     def test_from_content_disposition(self):
         mappings = [
@@ -32,7 +32,7 @@ class ResponseTypesTest(unittest.TestCase):
         ]
         for source, cls in mappings:
             retcls = responsetypes.from_content_disposition(source)
-            assert retcls is cls, "%s ==> %s != %s" % (source, retcls, cls)
+            assert retcls is cls, "{0!s} ==> {1!s} != {2!s}".format(source, retcls, cls)
 
     def test_from_content_type(self):
         mappings = [
@@ -46,7 +46,7 @@ class ResponseTypesTest(unittest.TestCase):
         ]
         for source, cls in mappings:
             retcls = responsetypes.from_content_type(source)
-            assert retcls is cls, "%s ==> %s != %s" % (source, retcls, cls)
+            assert retcls is cls, "{0!s} ==> {1!s} != {2!s}".format(source, retcls, cls)
 
     def test_from_body(self):
         mappings = [
@@ -57,7 +57,7 @@ class ResponseTypesTest(unittest.TestCase):
         ]
         for source, cls in mappings:
             retcls = responsetypes.from_body(source)
-            assert retcls is cls, "%s ==> %s != %s" % (source, retcls, cls)
+            assert retcls is cls, "{0!s} ==> {1!s} != {2!s}".format(source, retcls, cls)
 
     def test_from_headers(self):
         mappings = [
@@ -68,7 +68,7 @@ class ResponseTypesTest(unittest.TestCase):
         for source, cls in mappings:
             source = Headers(source)
             retcls = responsetypes.from_headers(source)
-            assert retcls is cls, "%s ==> %s != %s" % (source, retcls, cls)
+            assert retcls is cls, "{0!s} ==> {1!s} != {2!s}".format(source, retcls, cls)
 
     def test_from_args(self):
         # TODO: add more tests that check precedence between the different arguments
@@ -82,7 +82,7 @@ class ResponseTypesTest(unittest.TestCase):
         ]
         for source, cls in mappings:
             retcls = responsetypes.from_args(**source)
-            assert retcls is cls, "%s ==> %s != %s" % (source, retcls, cls)
+            assert retcls is cls, "{0!s} ==> {1!s} != {2!s}".format(source, retcls, cls)
 
     def test_custom_mime_types_loaded(self):
         # check that mime.types files shipped with scrapy are loaded

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -98,8 +98,8 @@ class SelectorTestCase(unittest.TestCase):
         """Check that classes are using slots and are weak-referenceable"""
         x = Selector(text='')
         weakref.ref(x)
-        assert not hasattr(x, '__dict__'), "%s does not use __slots__" % \
-            x.__class__.__name__
+        assert not hasattr(x, '__dict__'), "{0!s} does not use __slots__".format( \
+            x.__class__.__name__)
 
     def test_deprecated_selector_methods(self):
         sel = Selector(TextResponse(url="http://example.com", body=b'<p>some text</p>'))

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -16,7 +16,7 @@ class DeprecatedClassesTest(unittest.TestCase):
         for cls in [ScrapyHTMLTranslator, ScrapyGenericTranslator, ScrapyXPathExpr]:
             with warnings.catch_warnings(record=True) as w:
                 obj = cls()
-                self.assertIn('%s is deprecated' % cls.__name__, str(w[-1].message),
-                              'Missing deprecate warning for %s' % cls.__name__)
+                self.assertIn('{0!s} is deprecated'.format(cls.__name__), str(w[-1].message),
+                              'Missing deprecate warning for {0!s}'.format(cls.__name__))
 
 

--- a/tests/test_utils_defer.py
+++ b/tests/test_utils_defer.py
@@ -34,15 +34,15 @@ class MustbeDeferredTest(unittest.TestCase):
         return dfd
 
 def cb1(value, arg1, arg2):
-    return "(cb1 %s %s %s)" % (value, arg1, arg2)
+    return "(cb1 {0!s} {1!s} {2!s})".format(value, arg1, arg2)
 def cb2(value, arg1, arg2):
-    return defer.succeed("(cb2 %s %s %s)" % (value, arg1, arg2))
+    return defer.succeed("(cb2 {0!s} {1!s} {2!s})".format(value, arg1, arg2))
 def cb3(value, arg1, arg2):
-    return "(cb3 %s %s %s)" % (value, arg1, arg2)
+    return "(cb3 {0!s} {1!s} {2!s})".format(value, arg1, arg2)
 def cb_fail(value, arg1, arg2):
     return Failure(TypeError())
 def eb1(failure, arg1, arg2):
-    return "(eb1 %s %s %s)" % (failure.value.__class__.__name__, arg1, arg2)
+    return "(eb1 {0!s} {1!s} {2!s})".format(failure.value.__class__.__name__, arg1, arg2)
 
 
 class DeferUtilsTest(unittest.TestCase):

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -302,7 +302,7 @@ def create_guess_scheme_t(args):
     def do_expected(self):
         url = guess_scheme(args[0])
         assert url.startswith(args[1]), \
-            'Wrong scheme guessed: for `%s` got `%s`, expected `%s...`' % (
+            'Wrong scheme guessed: for `{0!s}` got `{1!s}`, expected `{2!s}...`'.format(
                 args[0], url, args[1])
     return do_expected
 
@@ -340,7 +340,7 @@ for k, args in enumerate ([
 
         ], start=1):
     t_method = create_guess_scheme_t(args)
-    t_method.__name__ = 'test_uri_%03d' % k
+    t_method.__name__ = 'test_uri_{0:03d}'.format(k)
     setattr (GuessSchemeTest, t_method.__name__, t_method)
 
 # TODO: the following tests do not pass with current implementation
@@ -349,7 +349,7 @@ for k, args in enumerate ([
              'Windows filepath are not supported for scrapy shell'),
         ], start=1):
     t_method = create_skipped_scheme_t(args)
-    t_method.__name__ = 'test_uri_skipped_%03d' % k
+    t_method.__name__ = 'test_uri_skipped_{0:03d}'.format(k)
     setattr (GuessSchemeTest, t_method.__name__, t_method)
 
 

--- a/tests/test_webclient.py
+++ b/tests/test_webclient.py
@@ -250,7 +250,7 @@ class WebClientTestCase(unittest.TestCase):
         return self.port.stopListening()
 
     def getURL(self, path):
-        return "http://127.0.0.1:%d/%s" % (self.portno, path)
+        return "http://127.0.0.1:{0:d}/{1!s}".format(self.portno, path)
 
     def testPayload(self):
         s = "0123456789" * 10
@@ -262,7 +262,7 @@ class WebClientTestCase(unittest.TestCase):
         # it should extract from url
         return defer.gatherResults([
             getPage(self.getURL("host")).addCallback(
-                self.assertEquals, to_bytes("127.0.0.1:%d" % self.portno)),
+                self.assertEquals, to_bytes("127.0.0.1:{0:d}".format(self.portno))),
             getPage(self.getURL("host"), headers={"Host": "www.example.com"}).addCallback(
                 self.assertEquals, to_bytes("www.example.com"))])
 
@@ -298,7 +298,7 @@ class WebClientTestCase(unittest.TestCase):
         """
         d = getPage(self.getURL("host"), timeout=100)
         d.addCallback(
-            self.assertEquals, to_bytes("127.0.0.1:%d" % self.portno))
+            self.assertEquals, to_bytes("127.0.0.1:{0:d}".format(self.portno)))
         return d
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:scrapy?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:scrapy?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
